### PR TITLE
Ignore .ssh/config when connecting to VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ it is running, and how to connect to it.  For example,
 ```
 $ ccloudvm status
 Status	:	ciao up
-SSH	:	ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /home/user/.ccloudvm/id_rsa 127.0.0.1 -p 10022
+SSH	:	ssh -q -F /dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /home/user/.ccloudvm/id_rsa 127.0.0.1 -p 10022
 ```
 
 ### stop

--- a/ccloudvm.go
+++ b/ccloudvm.go
@@ -506,7 +506,8 @@ func connect(ctx context.Context, errCh chan error) {
 	}
 
 	err = syscall.Exec(path, []string{path,
-		"-q", "-o", "UserKnownHostsFile=/dev/null",
+		"-q", "-F", "/dev/null",
+		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "IdentitiesOnly=yes",
 		"-i", ws.keyPath,

--- a/vm.go
+++ b/vm.go
@@ -160,7 +160,7 @@ func statusVM(ctx context.Context, instanceDir, keyPath, workloadName string, ss
 	ssh := "N/A"
 	if sshReady(ctx, sshPort) {
 		status = "VM up"
-		ssh = fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s 127.0.0.1 -p %d", keyPath, sshPort)
+		ssh = fmt.Sprintf("ssh -q -F /dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s 127.0.0.1 -p %d", keyPath, sshPort)
 	}
 
 	w := new(tabwriter.Writer)


### PR DESCRIPTION
Settings in the user's .ssh/config file on the host VM can cause issues
when connecting to the guest VM.  cccloudvm has all the information it
needs to connect to the guest VM and we don't want this information to
be overridden by settings in the .ssh/config file.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>