### PR TITLE
Fix vendoring of ciao packages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,12 @@
 
 [[projects]]
   name = "github.com/ciao-project/ciao"
-  packages = ["clogger","deviceinfo","osprepare","uuid"]
+  packages = [
+    "clogger",
+    "deviceinfo",
+    "osprepare",
+    "uuid"
+  ]
   revision = "194264adc5835bca8bb6fa70cf61330a8ed64764"
 
 [[projects]]
@@ -15,6 +20,7 @@
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  revision = ""
   version = "v1.0.0"
 
 [[projects]]
@@ -26,6 +32,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b1733143571f6b77c233fa2a63490ddcb37a1fd63a39092a3183be0c67637d79"
+  inputs-digest = "1dacc0d637dcd1284d3e450dbd487563a38d3ba06f1b818068f5c91102245e3f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/ciao-project/ciao"
-  revision = "60525fba8e5f4f1bf3ad02b8f5854c4dcf735a78"
+  revision = "194264adc5835bca8bb6fa70cf61330a8ed64764"
 
 [[constraint]]
   name = "github.com/pmezard/go-difflib"


### PR DESCRIPTION
The Gopkg.toml entry for ciao was incorrect.  This led to ciao packages
actually getting downgraded when performing a dep ensure --update.  This
commit fixes the error.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>