### PR TITLE
Add semaphore.sh file

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -1,0 +1,147 @@
+
+#!/bin/bash
+
+set -e
+
+function finish {
+    error_code=$?
+
+    if [ $created -eq 1 ]
+    then
+	ccloudvm delete
+    fi
+
+    echo ""
+    echo "=============================="
+    if [[ $error_code -eq 0 ]]
+    then
+	echo "=          SUCCESS           ="
+    else
+	echo "=          FAILURE           ="
+    fi
+    echo "=============================="
+}
+
+trap finish EXIT
+
+created=0
+
+if [[ ! -z "${SEMAPHORE_REPO_SLUG}" ]]
+then
+    echo ""
+    echo "===== Cloning repo ====="
+    echo ""
+
+    if [ "$SEMAPHORE_REPO_SLUG" != "intel/ccloudvm" ]
+    then
+	mkdir -p $GOPATH/src/github.com/intel
+	mv $GOPATH/src/github.com/${SEMAPHORE_REPO_SLUG} $GOPATH/src/github.com/intel/ccloudvm
+	cd $GOPATH/src/github.com/intel/ccloudvm
+	git checkout ${BRANCH_NAME}
+    fi
+
+    go get -d -t ./...
+
+    echo ""
+    echo "===== Installing packages ====="
+    echo ""
+
+    sudo apt-get update
+    sudo apt-get install qemu xorriso -y
+    sudo chmod ugo+rwx /dev/kvm
+fi
+
+echo ""
+echo "===== Building ccloudvm ====="
+echo ""
+
+go version
+go get github.com/intel/ccloudvm
+
+export PATH=$GOPATH/bin:$PATH
+
+# Create and boot a semaphore instance
+
+echo ""
+echo "===== Creating instance ====="
+echo ""
+
+ccloudvm create --debug --port "8000-80" --package-upgrade=false semaphore
+
+created=1
+
+echo ""
+echo "===== Testing SSH ====="
+echo ""
+
+myssh=`ccloudvm status | grep ssh`
+mysshcmd=`echo $myssh | cut -d : -f 2`
+
+# SSH to the instance and execute a command to determine the remote user
+
+lsb_release_cmd="$mysshcmd lsb_release -c -s"
+remote_distro=`$lsb_release_cmd`
+echo "Check $remote_distro == xenial"
+test $remote_distro = "xenial"
+
+echo ""
+echo "===== Testing port mapping ====="
+echo ""
+
+# Get port mapping is working by send a http GET to the nginx server running in
+# the VM
+
+http_proxy= curl http://localhost:8000
+
+# Stop the VM
+
+echo ""
+echo "===== Testing ccloudvm stop ====="
+echo ""
+
+ccloudvm stop
+
+# Check there are no qemu processes running.  A bit racy I know.  It would
+# be better if stop waited until the qemu process had actually exited.
+#
+# For the time being we're only going to enable this test inside semaphore
+# builds as it could easily fail on a development machine.
+
+if [[ ! -z "${SEMAPHORE_REPO_SLUG}" ]]
+then
+    retry=0
+    until [ $retry -ge 12 ]
+    do
+	if ! pidof qemu-system-x86_64
+	then
+	    break
+	fi
+
+	let retry=retry+1
+	sleep 5
+    done
+
+    if [ $retry -eq 12 ]
+    then
+	echo "qemu process did not exit"
+	false
+    fi
+fi
+
+# Delete the instance
+
+echo ""
+echo "===== Testing ccloudvm delete ====="
+echo ""
+
+ccloudvm delete
+
+created=0
+
+# Check it's really gone
+
+if test -d ~/.ccloudvm/instance
+then
+    echo "~/.ccloudvm/instance still exists"
+    false
+fi

--- a/workloads/semaphore.yaml
+++ b/workloads/semaphore.yaml
@@ -1,0 +1,64 @@
+---
+base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+base_image_name: Ubuntu 16.04
+...
+---
+{{- define "ENV" -}}
+{{proxyVars .}}
+{{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}
+{{end}}
+#cloud-config
+write_files:
+{{- if len $.HTTPProxy }}
+ - content: |
+     [Service]
+     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
+   path: /etc/systemd/system/docker.service.d/http-proxy.conf
+{{- end}}
+{{with proxyEnv . 5}}
+ - content: |
+{{.}}
+   path: /etc/environment
+{{end}}
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+packages:
+ - nginx
+package_upgrade: {{with .PackageUpgrade}}{{.}}{{else}}false{{end}}
+
+runcmd:
+ - {{beginTask . "Booting VM"}}
+ - {{endTaskOk . }}
+
+ - {{beginTask . (printf "Adding %s to /etc/hosts" .Hostname) }}
+ - echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts
+ - {{endTaskCheck .}}
+
+{{range .Mounts}}
+ - mkdir -p {{.Path}}
+ - sudo chown {{$.User}}:{{$.User}} {{.Tag}}
+ - echo "{{.Tag}} {{.Path}} 9p x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L 0 0" >> /etc/fstab
+{{end}}
+{{range .Mounts}}
+ - {{beginTask $ (printf "Mounting %s" .Path) }}
+ - mount {{.Path}}
+ - {{endTaskCheck $}}
+{{end}}
+
+ - {{finished .}}
+
+users:
+  - name: {{.User}}
+    gecos: CIAO Demo User
+    lock-passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - {{.PublicKey}}
+...


### PR DESCRIPTION
Add the semaphore.sh bash file which will be called from semaphore CI builds.
This script runs some basic sanity checks on ccloudvm.  Currently, it

- Builds the code
- Creates a ccloudvm instance using the semaphore workload
- SSHes into the instance and checks the release is xenial
- Does a HTTP Get on the local host on a port mapped to port 80
  on the ccloudvm instance.  The workload installs and runs
  nginx so the get should succeed.
- Stops the instance and checks the qemu process has quit
- Deletes the instance and checks that the instance directory has dissapeared.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>