### PR TITLE
CCloudvm no longer uses template.Must

### DIFF
--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -342,19 +342,26 @@ func buildISOImage(ctx context.Context, instanceDir, tmpl string, ws *workspace,
 		"finished":     finishedFN,
 	}
 
-	udt := template.Must(template.New("user-data").Funcs(funcMap).Parse(tmpl))
+	udt, err := template.New("user-data").Funcs(funcMap).Parse(tmpl)
+	if err != nil {
+		return fmt.Errorf("Unable to parse user data template : %v", err)
+	}
+
+	mdt, err := template.New("meta-data").Parse(metaDataTemplate)
+	if err != nil {
+		return fmt.Errorf("Unable to parse meta data template : %v", err)
+	}
+
 	var udBuf bytes.Buffer
-	err := udt.Execute(&udBuf, ws)
+	err = udt.Execute(&udBuf, ws)
 	if err != nil {
 		return fmt.Errorf("Unable to execute user data template : %v", err)
 	}
 
-	mdt := template.Must(template.New("meta-data").Parse(metaDataTemplate))
-
 	var mdBuf bytes.Buffer
 	err = mdt.Execute(&mdBuf, ws)
 	if err != nil {
-		return fmt.Errorf("Unable to execute user data template : %v", err)
+		return fmt.Errorf("Unable to execute meta data template : %v", err)
 	}
 
 	if debug {


### PR DESCRIPTION
When ccloudvm was first written it supported only one workload, ciao.
This workload was built into the ccloudvm binary as a Go string.  When
parsing the workload, template.Must was used.  This made sense as any
syntax errors in the template were indicative of a problem with
ccloudvm itself.  Now however, workloads are user supplied and so can
often contain errors.  Panicing on error is no longer the correct
thing to do.  It also means that the VM under construction does not
get cleaned up correctly.

Fixes: https://github.com/intel/ccloudvm/issues/14

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>