### PR TITLE
 Allow user to specify the size of the rootfs 

### DIFF
--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -215,12 +215,12 @@ func Create(ctx context.Context, workloadName string, debug bool, update bool, c
 		return err
 	}
 
-	err = createRootfs(ctx, qcowPath, ws.instanceDir)
+	spec := wkld.spec.VM
+	err = createRootfs(ctx, qcowPath, ws.instanceDir, spec.DiskGiB)
 	if err != nil {
 		return err
 	}
 
-	spec := wkld.spec.VM
 	fmt.Printf("Booting VM with %d GB RAM and %d cpus\n", spec.MemGiB, spec.CPUs)
 
 	err = bootVM(ctx, ws, &spec)

--- a/ccvm/instance.go
+++ b/ccvm/instance.go
@@ -76,6 +76,7 @@ func (d drive) String() string {
 // VMSpec holds the per-VM state.
 type VMSpec struct {
 	MemGiB       int    `yaml:"mem_gib"`
+	DiskGiB      int    `yaml:"disk_gib"`
 	CPUs         int    `yaml:"cpus"`
 	PortMappings ports  `yaml:"ports"`
 	Mounts       mounts `yaml:"mounts"`
@@ -163,6 +164,10 @@ func (in *VMSpec) unmarshal(data []byte) error {
 		if in.CPUs == 0 {
 			in.CPUs = cpuDef
 		}
+	}
+
+	if in.DiskGiB == 0 {
+		in.DiskGiB = 60
 	}
 
 	var i int
@@ -261,6 +266,9 @@ func (in *VMSpec) mergeCustom(customSpec *VMSpec) error {
 	}
 	if customSpec.CPUs != 0 {
 		in.CPUs = customSpec.CPUs
+	}
+	if customSpec.DiskGiB != 0 {
+		in.DiskGiB = customSpec.DiskGiB
 	}
 	if customSpec.Qemuport != 0 {
 		in.Qemuport = customSpec.Qemuport

--- a/ccvm/instance.go
+++ b/ccvm/instance.go
@@ -36,6 +36,8 @@ const (
 	CLEARCONTAINERS = "clearcontainers"
 )
 
+const defaultRootFSSize = 60
+
 // Constants for the Guest image used by ccloudvm
 
 const (
@@ -167,7 +169,7 @@ func (in *VMSpec) unmarshal(data []byte) error {
 	}
 
 	if in.DiskGiB == 0 {
-		in.DiskGiB = 60
+		in.DiskGiB = defaultRootFSSize
 	}
 
 	var i int

--- a/ccvm/mock_test.go
+++ b/ccvm/mock_test.go
@@ -51,6 +51,7 @@ vm:
 var mockVMSpec = VMSpec{
 	MemGiB:       3,
 	CPUs:         2,
+	DiskGiB:      60,
 	PortMappings: []portMapping{{Host: 10022, Guest: 22}},
 	Mounts:       []mount{},
 }

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -372,15 +372,14 @@ func buildISOImage(ctx context.Context, instanceDir, tmpl string, ws *workspace,
 	return createCloudInitISO(ctx, instanceDir, udBuf.Bytes(), mdBuf.Bytes())
 }
 
-// TODO: Code copied from launcher.  Needs to be moved to qemu
-
-func createRootfs(ctx context.Context, backingImage, instanceDir string) error {
+func createRootfs(ctx context.Context, backingImage, instanceDir string, disk int) error {
 	vmImage := path.Join(instanceDir, "image.qcow2")
 	if _, err := os.Stat(vmImage); err == nil {
 		_ = os.Remove(vmImage)
 	}
+	diskParam := fmt.Sprintf("%dG", disk)
 	params := make([]string, 0, 32)
 	params = append(params, "create", "-f", "qcow2", "-o", "backing_file="+backingImage,
-		vmImage, "60000M")
+		vmImage, diskParam)
 	return exec.CommandContext(ctx, "qemu-img", params...).Run()
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,6 +44,7 @@ func init() {
 
 	var flags flag.FlagSet
 	ccvm.VMFlags(&flags, &createSpec)
+	flags.IntVar(&createSpec.DiskGiB, "disk", createSpec.DiskGiB, "Gibibytes of disk space allocated to Rootfs")
 
 	createCmd.Flags().AddGoFlagSet(&flags)
 	createCmd.Flags().BoolVar(&createDebug, "debug", false, "Enable debugging mode")

--- a/workloads/artful.yaml
+++ b/workloads/artful.yaml
@@ -1,6 +1,8 @@
 ---
 base_image_url: https://cloud-images.ubuntu.com/artful/current/artful-server-cloudimg-amd64.img
 base_image_name: Ubuntu 17.10
+vm:
+  disk_gib: 16
 ...
 ---
 {{- define "ENV" -}}

--- a/workloads/fedora25.yaml
+++ b/workloads/fedora25.yaml
@@ -2,6 +2,8 @@
 base_image_url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-25-1.3.x86_64.qcow2
 base_image_name: Fedora 25
 hostname: singlevm
+vm:
+  disk_gib: 16
 ...
 ---
 #cloud-config

--- a/workloads/fedora27.yaml
+++ b/workloads/fedora27.yaml
@@ -2,6 +2,8 @@
 base_image_url: https://mirror.us-midwest-1.nexcess.net/fedora/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
 base_image_name: Fedora 27
 hostname: singlevm
+vm:
+  disk_gib: 16
 ...
 ---
 #cloud-config

--- a/workloads/xenial.yaml
+++ b/workloads/xenial.yaml
@@ -1,6 +1,8 @@
 ---
 base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
 base_image_name: Ubuntu 16.04
+vm:
+  disk_gib: 16
 ...
 ---
 {{- define "ENV" -}}


### PR DESCRIPTION
Up until now ccloudvm assigns an arbitray maximum size of 60 Gibs to the rootfs of the newly created VM.  The user was unable to override this value, either in the workload file or on the command line.  This commit allows the user to do both of these things.  The default is still 60Gib if the a size is not specified in the workload or by the user.

The PR also adds a new unit test and updates the default rootfs size for the generic workloads to 16GB.