### PR TITLE
workloads/ciao: Update ciao workload from docker to docker-ce

### DIFF
--- a/workloads/ciao.yaml
+++ b/workloads/ciao.yaml
@@ -40,7 +40,7 @@ write_files:
    path: /etc/update-motd.d/10-ciao-help-text
    permissions: '0755'
  - content: |
-     deb https://apt.dockerproject.org/repo ubuntu-xenial main
+     deb https://download.docker.com/linux/ubuntu xenial stable
    path: /etc/apt/sources.list.d/docker.list
  - content: |
      deb http://apt.kubernetes.io/ kubernetes-xenial main
@@ -100,7 +100,7 @@ runcmd:
  - {{endTaskCheck .}}
 
  - {{beginTask . "Add docker GPG key" }}
- - {{template "ENV" .}}apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+ - {{template "ENV" .}}curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
  - {{endTaskCheck .}}
 
  - {{beginTask . "Add Google GPG key" }}
@@ -112,7 +112,7 @@ runcmd:
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing Docker"}}
- - {{template "ENV" .}}apt-get install docker-engine -y
+ - {{template "ENV" .}}apt-get install docker-ce -y
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing kubectl"}}


### PR DESCRIPTION
Old docker repository and package name works but has been deprecated.

Fixes: #19

Signed-off-by: Rob Bradford <robert.bradford@intel.com>