### PR TITLE
ccvm: Switch memory unit from GB to MiBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-clo
 base_image_name: Ubuntu 16.04
 ...
 ---
-mem_gib: 2
+mem_mib: 2048
 cpus: 2
 ...
 ---
@@ -178,7 +178,7 @@ The second document is called the instance data document.  It contains informati
 set when an instance is first created but may be modified at a later date, without deleting
 the instance.    Four fields are currently defined:
 
-- mem_gib : Number of Gigabytes to assign to the VM.  Defaults to half the memory on your machine
+- mem_mib : Number of mebibytes to assign to the VM.  Defaults to half the memory on your machine
 - cpus    : Number of CPUs to assign to the VM.  Defaults to half the cores on your machine
 - ports   : Slice of port objects which map host ports on 127.0.0.1 to guest ports
 - mounts  : Slice of mount objects which describe the folders shared between the host and the guest

--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -101,7 +101,7 @@ func (d *drives) Set(value string) error {
 
 // VMFlags provides common flags for customising a workload
 func VMFlags(fs *flag.FlagSet, customSpec *VMSpec) {
-	fs.IntVar(&customSpec.MemGiB, "mem", customSpec.MemGiB, "Gigabytes of RAM allocated to VM")
+	fs.IntVar(&customSpec.MemMiB, "mem", customSpec.MemMiB, "Mebibytes of RAM allocated to VM")
 	fs.IntVar(&customSpec.CPUs, "cpus", customSpec.CPUs, "VCPUs assigned to VM")
 	fs.Var(&customSpec.Mounts, "mount", "directory to mount in guest VM via 9p. Format is tag,security_model,path")
 	fs.Var(&customSpec.Drives, "drive", "Host accessible resource to appear as block device in guest VM.  Format is path,format[,option]*")
@@ -223,7 +223,7 @@ func Create(ctx context.Context, workloadName string, debug bool, update bool, c
 		return err
 	}
 
-	fmt.Printf("Booting VM with %d GB RAM and %d cpus\n", spec.MemGiB, spec.CPUs)
+	fmt.Printf("Booting VM with %d MiB RAM and %d cpus\n", spec.MemMiB, spec.CPUs)
 
 	err = bootVM(ctx, ws, &spec)
 	if err != nil {
@@ -260,8 +260,8 @@ func Start(ctx context.Context, customSpec *VMSpec) error {
 	}
 
 	memGiB, CPUs := getMemAndCpus()
-	if in.MemGiB == 0 {
-		in.MemGiB = memGiB
+	if in.MemMiB == 0 {
+		in.MemMiB = memGiB * 1024
 	}
 	if in.CPUs == 0 {
 		in.CPUs = CPUs
@@ -275,7 +275,7 @@ func Start(ctx context.Context, customSpec *VMSpec) error {
 		fmt.Printf("Warning: Failed to update instance state: %v", err)
 	}
 
-	fmt.Printf("Booting VM with %d GB RAM and %d cpus\n", in.MemGiB, in.CPUs)
+	fmt.Printf("Booting VM with %d MiB RAM and %d cpus\n", in.MemMiB, in.CPUs)
 
 	err = bootVM(ctx, ws, in)
 	if err != nil {

--- a/ccvm/ccvm_test.go
+++ b/ccvm/ccvm_test.go
@@ -67,7 +67,7 @@ func TestSystem(t *testing.T) {
 	}()
 
 	vmSpec := &VMSpec{
-		MemGiB: 1,
+		MemMiB: 1024,
 		CPUs:   1,
 		Mounts: []mount{
 			{

--- a/ccvm/instance.go
+++ b/ccvm/instance.go
@@ -78,7 +78,7 @@ func (d drive) String() string {
 
 // VMSpec holds the per-VM state.
 type VMSpec struct {
-	MemGiB       int    `yaml:"mem_gib"`
+	MemMiB       int    `yaml:"mem_mib"`
 	DiskGiB      int    `yaml:"disk_gib"`
 	CPUs         int    `yaml:"cpus"`
 	PortMappings ports  `yaml:"ports"`
@@ -159,10 +159,10 @@ func (in *VMSpec) unmarshal(data []byte) error {
 	}
 
 	var memDef, cpuDef int
-	if in.MemGiB == 0 || in.CPUs == 0 {
+	if in.MemMiB == 0 || in.CPUs == 0 {
 		memDef, cpuDef = getMemAndCpus()
-		if in.MemGiB == 0 {
-			in.MemGiB = memDef
+		if in.MemMiB == 0 {
+			in.MemMiB = memDef
 		}
 		if in.CPUs == 0 {
 			in.CPUs = cpuDef
@@ -264,8 +264,8 @@ func (in *VMSpec) mergeCustom(customSpec *VMSpec) error {
 		}
 	}
 
-	if customSpec.MemGiB != 0 {
-		in.MemGiB = customSpec.MemGiB
+	if customSpec.MemMiB != 0 {
+		in.MemMiB = customSpec.MemMiB
 	}
 	if customSpec.CPUs != 0 {
 		in.CPUs = customSpec.CPUs

--- a/ccvm/mock_test.go
+++ b/ccvm/mock_test.go
@@ -31,7 +31,7 @@ base_image_name: ` + guestImageFriendlyName + `
 `
 
 const sampleVMSpec = `
-mem_gib: 3
+mem_mib: 3072
 cpus: 2
 ports:
 - host: 10022
@@ -43,7 +43,7 @@ const xenialWorkloadSpec = `
 base_image_url: ` + guestDownloadURL + `
 base_image_name: ` + guestImageFriendlyName + `
 vm:
-  mem_gib: 3
+  mem_mib: 3072
   cpus: 2
   ports:
   - host: 10022
@@ -52,7 +52,7 @@ vm:
 `
 
 var mockVMSpec = VMSpec{
-	MemGiB:       3,
+	MemMiB:       3072,
 	CPUs:         2,
 	DiskGiB:      defaultRootFSSize,
 	PortMappings: []portMapping{{Host: 10022, Guest: 22}},

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -52,7 +52,7 @@ func bootVM(ctx context.Context, ws *workspace, in *VMSpec) error {
 
 	vmImage := path.Join(ws.instanceDir, "image.qcow2")
 	isoPath := path.Join(ws.instanceDir, "config.iso")
-	memParam := fmt.Sprintf("%dG", in.MemGiB)
+	memParam := fmt.Sprintf("%dM", in.MemMiB)
 	CPUsParam := fmt.Sprintf("cpus=%d", in.CPUs)
 	args := []string{
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", socket),

--- a/ccvm/workload_test.go
+++ b/ccvm/workload_test.go
@@ -114,7 +114,7 @@ func TestCreateWorkload(t *testing.T) {
 			if workload.spec.VM.CPUs == 0 {
 				t.Errorf("CPUs should be greater than 0")
 			}
-			if workload.spec.VM.MemGiB == 0 {
+			if workload.spec.VM.MemMiB == 0 {
 				t.Errorf("Memory should be greater than 0")
 			}
 			if len(workload.spec.VM.PortMappings) == 0 {


### PR DESCRIPTION
Using the smaller unit is a bit more practical for memory usage for VMs.

Sort of fixes: #10

Signed-off-by: Rob Bradford <robert.bradford@intel.com>