### PR TITLE
ccvm: remove legacy support

### DIFF
--- a/ccvm/download.go
+++ b/ccvm/download.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 
@@ -140,15 +139,6 @@ func downloadFile(ctx context.Context, URL, ccvmDir string, cb progressCB) (stri
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return "", fmt.Errorf("Unable to create directory %s : %v",
 			cacheDir, err)
-	}
-
-	// Handles legacy code in which the ubuntu image used to be stored in
-	// the root of the ~/.ccloudvm directory.  We don't want to move the
-	// old image as this would break any existing VMs based off it.
-
-	oldImgPath := path.Join(ccvmDir, di.imageName)
-	if err := exec.Command("cp", oldImgPath, imgPath).Run(); err == nil {
-		return imgPath, nil
 	}
 
 	tmpImgPath := path.Join(cacheDir, di.imageTmpName)

--- a/ccvm/mock_test.go
+++ b/ccvm/mock_test.go
@@ -25,20 +25,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const xenialWorkloadSpecNoVM = `
-base_image_url: ` + guestDownloadURL + `
-base_image_name: ` + guestImageFriendlyName + `
-`
-
-const sampleVMSpec = `
-mem_mib: 3072
-cpus: 2
-ports:
-- host: 10022
-  guest: 22
-mounts: []
-`
-
 const xenialWorkloadSpec = `
 base_image_url: ` + guestDownloadURL + `
 base_image_name: ` + guestImageFriendlyName + `
@@ -62,7 +48,6 @@ var mockVMSpec = VMSpec{
 const sampleCloudInit = `
 `
 
-const sampleWorkload3Docs = "---\n" + xenialWorkloadSpecNoVM + "...\n---\n" + sampleVMSpec + "...\n---\n" + sampleCloudInit + "...\n"
 const sampleWorkload = "---\n" + xenialWorkloadSpec + "...\n---\n" + sampleCloudInit + "...\n"
 
 func createMockWorkSpaceWithWorkload(workload, workloadName, ccvmDir string) (*workspace, error) {

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -202,10 +202,7 @@ func prepareEnv(ctx context.Context) (*workspace, error) {
 	}
 
 	ws.NoProxy = os.Getenv("no_proxy")
-	ws.ccvmDir = path.Join(ws.Home, ".ciao-down")
-	if _, err := os.Stat(ws.ccvmDir); err != nil {
-		ws.ccvmDir = path.Join(ws.Home, ".ccloudvm")
-	}
+	ws.ccvmDir = path.Join(ws.Home, ".ccloudvm")
 	ws.instanceDir = path.Join(ws.ccvmDir, "instance")
 	ws.keyPath = path.Join(ws.ccvmDir, "id_rsa")
 	ws.publicKeyPath = fmt.Sprintf("%s.pub", ws.keyPath)

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -189,10 +189,7 @@ func restoreWorkload(ws *workspace) (*workload, error) {
 	var wkld workload
 	data, err := ioutil.ReadFile(path.Join(ws.instanceDir, "state.yaml"))
 	if err != nil {
-		if err = wkld.spec.VM.loadLegacyInstance(ws); err != nil {
-			return nil, err
-		}
-		return &wkld, nil
+		return nil, errors.Wrap(err, "Error reading workload")
 	}
 
 	docs := splitYaml(data)

--- a/ccvm/workload_test.go
+++ b/ccvm/workload_test.go
@@ -125,16 +125,8 @@ func TestCreateWorkload(t *testing.T) {
 }
 
 func TestRestoreWorkload(t *testing.T) {
-	tests := []struct {
-		checkSpec bool // Should we check the workload.spec content?
-		workload  string
-	}{
-		// 1 document: per-VM data (legacy)
-		{workload: sampleVMSpec},
-		// 2 documents: spec, cloud init file
-		{workload: sampleWorkload, checkSpec: true},
-		// 3 documents: spec, per-VM data, cloud init file (legacy)
-		{workload: sampleWorkload3Docs, checkSpec: true},
+	workloads := []string{
+		sampleWorkload,
 	}
 
 	ccvmDir, err := ioutil.TempDir("", "ccloudvm-tests-")
@@ -148,10 +140,8 @@ func TestRestoreWorkload(t *testing.T) {
 		}
 	}()
 
-	for i := range tests {
-		test := &tests[i]
-
-		ws, err := createMockWorkSpaceWithInstance(test.workload, ccvmDir)
+	for i := range workloads {
+		ws, err := createMockWorkSpaceWithInstance(workloads[i], ccvmDir)
 		if err != nil {
 			t.Errorf("Failed to create mock workload : %v", err)
 			continue
@@ -168,19 +158,18 @@ func TestRestoreWorkload(t *testing.T) {
 			continue
 		}
 
-		if test.checkSpec {
-			if guestDownloadURL != workload.spec.BaseImageURL {
-				t.Errorf("URLs do not match expected %s got %s",
-					guestDownloadURL, workload.spec.BaseImageURL)
-			}
-			if guestImageFriendlyName != workload.spec.BaseImageName {
-				t.Errorf("Names do not match expected %s got %s",
-					guestImageFriendlyName, workload.spec.BaseImageName)
-			}
-			if defaultHostname != workload.spec.Hostname {
-				t.Errorf("Hostnames do not match expected %s got %s",
-					defaultHostname, workload.spec.Hostname)
-			}
+		if guestDownloadURL != workload.spec.BaseImageURL {
+			t.Errorf("URLs do not match expected %s got %s",
+				guestDownloadURL, workload.spec.BaseImageURL)
 		}
+		if guestImageFriendlyName != workload.spec.BaseImageName {
+			t.Errorf("Names do not match expected %s got %s",
+				guestImageFriendlyName, workload.spec.BaseImageName)
+		}
+		if defaultHostname != workload.spec.Hostname {
+			t.Errorf("Hostnames do not match expected %s got %s",
+				defaultHostname, workload.spec.Hostname)
+		}
+
 	}
 }


### PR DESCRIPTION
Remove support for loading legacy VM specification and metadata.

Fixes: #18

Signed-off-by: Rob Bradford <robert.bradford@intel.com>