### PR TITLE
Separate out common types into the types package

### DIFF
--- a/ccvm/ccvm_test.go
+++ b/ccvm/ccvm_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/intel/ccloudvm/types"
 )
 
 const standardTimeout = time.Second * 300
@@ -66,10 +68,10 @@ func TestSystem(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	vmSpec := &VMSpec{
+	vmSpec := &types.VMSpec{
 		MemMiB: 1024,
 		CPUs:   1,
-		Mounts: []mount{
+		Mounts: []types.Mount{
 			{
 				Tag:           "tmpdir",
 				SecurityModel: "passthrough",

--- a/ccvm/mock_test.go
+++ b/ccvm/mock_test.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/intel/ccloudvm/types"
 	"github.com/pkg/errors"
 )
 
@@ -37,12 +38,12 @@ vm:
   mounts: []
 `
 
-var mockVMSpec = VMSpec{
+var mockVMSpec = types.VMSpec{
 	MemMiB:       3072,
 	CPUs:         2,
 	DiskGiB:      defaultRootFSSize,
-	PortMappings: []portMapping{{Host: 10022, Guest: 22}},
-	Mounts:       []mount{},
+	PortMappings: []types.PortMapping{{Host: 10022, Guest: 22}},
+	Mounts:       []types.Mount{},
 }
 
 const sampleCloudInit = `

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/ciao-project/ciao/osprepare"
 	"github.com/ciao-project/ciao/uuid"
+	"github.com/intel/ccloudvm/types"
 	"github.com/intel/govmm/qemu"
 	"github.com/pkg/errors"
 )
@@ -77,7 +78,7 @@ type workspace struct {
 	HTTPServerPort int
 	GitUserName    string
 	GitEmail       string
-	Mounts         []mount
+	Mounts         []types.Mount
 	Hostname       string
 	UUID           string
 	PackageUpgrade string

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -30,6 +30,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/intel/ccloudvm/types"
 	"github.com/intel/govmm/qemu"
 	"github.com/pkg/errors"
 )
@@ -41,7 +42,7 @@ const (
 	urlParam          = "url"
 )
 
-func bootVM(ctx context.Context, ws *workspace, in *VMSpec) error {
+func bootVM(ctx context.Context, ws *workspace, in *types.VMSpec) error {
 	disconnectedCh := make(chan struct{})
 	socket := path.Join(ws.instanceDir, "socket")
 	qmp, _, err := qemu.QMPStart(ctx, socket, qemu.QMPConfig{}, disconnectedCh)

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -143,7 +143,7 @@ func unmarshalWorkload(ws *workspace, wkld *workload, spec, VMData,
 		return err
 	}
 
-	err = wkld.spec.VM.unmarshalWithTemplate(ws, VMData)
+	err = unmarshalWithTemplate(&wkld.spec.VM, ws, VMData)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func restoreWorkload(ws *workspace) (*workload, error) {
 	if len(docs) == 1 {
 		// Older versions of ccloudvm just stored the VM data and not the
 		// entire workload.
-		if err = wkld.spec.VM.unmarshalWithTemplate(ws, string(docs[0])); err != nil {
+		if err = unmarshalWithTemplate(&wkld.spec.VM, ws, string(docs[0])); err != nil {
 			return nil, err
 		}
 		return &wkld, nil

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,10 +20,12 @@ import (
 	"flag"
 
 	"github.com/intel/ccloudvm/ccvm"
+	"github.com/intel/ccloudvm/types"
 	"github.com/spf13/cobra"
 )
 
-var createSpec ccvm.VMSpec
+var createSpec types.VMSpec
+var createMOptsSpec multiOptions
 var createDebug bool
 var createPackageUpgrade bool
 
@@ -35,6 +37,7 @@ var createCmd = &cobra.Command{
 		ctx, cancelFunc := getSignalContext()
 		defer cancelFunc()
 
+		mergeVMOptions(&createSpec, &createMOptsSpec)
 		return ccvm.Create(ctx, args[0], createDebug, createPackageUpgrade, &createSpec)
 	},
 }
@@ -43,7 +46,7 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 
 	var flags flag.FlagSet
-	ccvm.VMFlags(&flags, &createSpec)
+	vmFlags(&flags, &createSpec, &createMOptsSpec)
 	flags.IntVar(&createSpec.DiskGiB, "disk", createSpec.DiskGiB, "Gibibytes of disk space allocated to Rootfs")
 
 	createCmd.Flags().AddGoFlagSet(&flags)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,10 +20,12 @@ import (
 	"flag"
 
 	"github.com/intel/ccloudvm/ccvm"
+	"github.com/intel/ccloudvm/types"
 	"github.com/spf13/cobra"
 )
 
-var startSpec ccvm.VMSpec
+var startSpec types.VMSpec
+var startMOptsSpec multiOptions
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -32,6 +34,7 @@ var startCmd = &cobra.Command{
 		ctx, cancelFunc := getSignalContext()
 		defer cancelFunc()
 
+		mergeVMOptions(&startSpec, &startMOptsSpec)
 		return ccvm.Start(ctx, &startSpec)
 	},
 }
@@ -40,7 +43,7 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 
 	var flags flag.FlagSet
-	ccvm.VMFlags(&flags, &startSpec)
+	vmFlags(&flags, &startSpec, &startMOptsSpec)
 
 	startCmd.Flags().AddGoFlagSet(&flags)
 }

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/intel/ccloudvm/types"
+	"github.com/pkg/errors"
+)
+
+type mounts []types.Mount
+type ports []types.PortMapping
+type drives []types.Drive
+
+type multiOptions struct {
+	m mounts
+	p ports
+	d drives
+}
+
+func (m *mounts) String() string {
+	return fmt.Sprint(*m)
+}
+
+func (m *mounts) Set(value string) error {
+	components := strings.Split(value, ",")
+	if len(components) != 3 {
+		return fmt.Errorf("--mount parameter should be of format tag,security_model,path")
+	}
+	*m = append(*m, types.Mount{
+		Tag:           components[0],
+		SecurityModel: components[1],
+		Path:          components[2],
+	})
+	return nil
+}
+
+func (p *ports) String() string {
+	return fmt.Sprint(*p)
+}
+
+func (p *ports) Set(value string) error {
+	components := strings.Split(value, "-")
+	if len(components) != 2 {
+		return fmt.Errorf("--port parameter should be of format host-guest")
+	}
+	host, err := strconv.Atoi(components[0])
+	if err != nil {
+		return fmt.Errorf("host port must be a number")
+	}
+	guest, err := strconv.Atoi(components[1])
+	if err != nil {
+		return fmt.Errorf("guest port must be a number")
+	}
+	*p = append(*p, types.PortMapping{
+		Host:  host,
+		Guest: guest,
+	})
+	return nil
+}
+
+func (d *drives) String() string {
+	return fmt.Sprint(*d)
+}
+
+func (d *drives) Set(value string) error {
+	components := strings.Split(value, ",")
+	if len(components) < 2 {
+		return fmt.Errorf("--drive parameter should be of format path,format[,option]*")
+	}
+	_, err := os.Stat(components[0])
+	if err != nil {
+		return errors.Wrapf(err, "Unable to access %s", components[1])
+	}
+	*d = append(*d, types.Drive{
+		Path:    components[0],
+		Format:  components[1],
+		Options: strings.Join(components[2:], ","),
+	})
+	return nil
+}
+
+func mergeVMOptions(vmSpec *types.VMSpec, mOpts *multiOptions) {
+	vmSpec.PortMappings = []types.PortMapping(mOpts.p)
+	vmSpec.Drives = []types.Drive(mOpts.d)
+	vmSpec.Mounts = []types.Mount(mOpts.m)
+}
+
+func vmFlags(fs *flag.FlagSet, customSpec *types.VMSpec, mOpts *multiOptions) {
+	fs.IntVar(&customSpec.MemMiB, "mem", customSpec.MemMiB, "Mebibytes of RAM allocated to VM")
+	fs.IntVar(&customSpec.CPUs, "cpus", customSpec.CPUs, "VCPUs assigned to VM")
+	fs.Var(&mOpts.m, "mount", "directory to mount in guest VM via 9p. Format is tag,security_model,path")
+	fs.Var(&mOpts.d, "drive", "Host accessible resource to appear as block device in guest VM.  Format is path,format[,option]*")
+	fs.Var(&mOpts.p, "port", "port mapping. Format is host_port-guest_port, e.g., -port 10022-22")
+	fs.UintVar(&customSpec.Qemuport, "qemuport", customSpec.Qemuport, "Port to follow qemu logs of the guest machine, eg., --qemuport=9999")
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,193 @@
+//
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package types
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+)
+
+// PortMapping exposes a guest resident service on the host
+type PortMapping struct {
+	Host  int `yaml:"host"`
+	Guest int `yaml:"guest"`
+}
+
+func (p PortMapping) String() string {
+	return fmt.Sprintf("%d-%d", p.Host, p.Guest)
+}
+
+// Mount contains information about a host path to be mounted inside the guest
+type Mount struct {
+	Tag           string `yaml:"tag"`
+	SecurityModel string `yaml:"security_model"`
+	Path          string `yaml:"path"`
+}
+
+func (m Mount) String() string {
+	return fmt.Sprintf("%s,%s,%s", m.Tag, m.SecurityModel, m.Path)
+}
+
+// Drive contains information about additional drives to mount in the guest
+type Drive struct {
+	Path    string
+	Format  string
+	Options string
+}
+
+func (d Drive) String() string {
+	return fmt.Sprintf("%s,%s,%s", d.Path, d.Format, d.Options)
+}
+
+// VMSpec holds the per-VM state.
+type VMSpec struct {
+	MemMiB       int           `yaml:"mem_mib"`
+	DiskGiB      int           `yaml:"disk_gib"`
+	CPUs         int           `yaml:"cpus"`
+	PortMappings []PortMapping `yaml:"ports"`
+	Mounts       []Mount       `yaml:"mounts"`
+	Drives       []Drive       `yaml:"drives"`
+	Qemuport     uint          `yaml:"qemuport"`
+}
+
+// CheckDirectory checks to see if a given absolute path exists and is
+// a directory.
+func CheckDirectory(dir string) error {
+	if dir == "" {
+		return nil
+	}
+
+	if !path.IsAbs(dir) {
+		return fmt.Errorf("%s is not an absolute path", dir)
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to stat %s", dir)
+	}
+
+	if !fi.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+
+	return nil
+}
+
+// MergeMounts merges a slice of mounts into an existing VMSpec.  Mounts
+// supplied in the m parameter override existing mounts in the VMSpec.
+func (in *VMSpec) MergeMounts(m []Mount) {
+	mountCount := len(in.Mounts)
+	for _, mount := range m {
+		var i int
+		for i = 0; i < mountCount; i++ {
+			if mount.Tag == in.Mounts[i].Tag {
+				break
+			}
+		}
+
+		if i == mountCount {
+			in.Mounts = append(in.Mounts, mount)
+		} else {
+			in.Mounts[i] = mount
+		}
+	}
+}
+
+// MergePorts merges a slice of ports into an existing VMSpec.  Ports
+// supplied in the p parameter override existing ports in the VMSpec.
+func (in *VMSpec) MergePorts(p []PortMapping) {
+	portCount := len(in.PortMappings)
+	for _, port := range p {
+		var i int
+		for i = 0; i < portCount; i++ {
+			if port.Guest == in.PortMappings[i].Guest {
+				break
+			}
+		}
+
+		if i == portCount {
+			in.PortMappings = append(in.PortMappings, port)
+		} else {
+			in.PortMappings[i] = port
+		}
+	}
+}
+
+// MergeDrives merges a slice of drives into an existing VMSpec.  Drives
+// supplied in the d parameter override existing drives in the VMSpec.
+func (in *VMSpec) MergeDrives(d []Drive) {
+	driveCount := len(in.Drives)
+	for _, drive := range d {
+		var i int
+		for i = 0; i < driveCount; i++ {
+			if drive.Path == in.Drives[i].Path {
+				break
+			}
+		}
+
+		if i == driveCount {
+			in.Drives = append(in.Drives, drive)
+		} else {
+			in.Drives[i] = drive
+		}
+	}
+}
+
+// MergeCustom merges one VMSpec into another.  In addition to merging
+// mounts, drives and ports, other fields in the receiver VM spec, such as
+// MemMiB, are also updated, with values provided by the customSpec parameter,
+// if they are not already defined.
+func (in *VMSpec) MergeCustom(customSpec *VMSpec) error {
+	for i := range customSpec.Mounts {
+		if err := CheckDirectory(customSpec.Mounts[i].Path); err != nil {
+			return err
+		}
+	}
+
+	if customSpec.MemMiB != 0 {
+		in.MemMiB = customSpec.MemMiB
+	}
+	if customSpec.CPUs != 0 {
+		in.CPUs = customSpec.CPUs
+	}
+	if customSpec.DiskGiB != 0 {
+		in.DiskGiB = customSpec.DiskGiB
+	}
+	if customSpec.Qemuport != 0 {
+		in.Qemuport = customSpec.Qemuport
+	}
+
+	in.MergeMounts(customSpec.Mounts)
+	in.MergePorts(customSpec.PortMappings)
+	in.MergeDrives(customSpec.Drives)
+
+	return nil
+}
+
+// SSHPort returns the port on the host which can be used to access the instance
+// described by the VMSpec.
+func (in *VMSpec) SSHPort() (int, error) {
+	for _, p := range in.PortMappings {
+		if p.Guest == 22 {
+			return p.Host, nil
+		}
+	}
+	return 0, fmt.Errorf("No SSH port configured")
+}


### PR DESCRIPTION
The forthcoming client and server will communicate via some public types.
This commit creates a new home for these public types; the types package.
These types already existed but were a little convoluted  as their
usage was overloaded somewhat.  Some of the methods they defined had
uses that were specific to one component.  For example, the ccvm package
doesn't need to know anything about parsing flags and the cmd package
doesn't need to know about marshalling and unmarshalling VMspecs.  For
this reason, some of the methods of the relocated types have been separated
out and moved into the packages where they logically belong.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>