### PR TITLE
ccvm: Implement workload spec inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ cpus: 2
 ---
 #cloud-config
 package_upgrade: false
-runcmd:
- - {{finished .}}
 
 users:
   - name: {{.User}}
@@ -338,14 +336,6 @@ if it fails.
 Reporting a failure back to ccloudvm does not cause the create command to exit.  The
 failure is presented to the user and the setup of the VM continues.
 
-#### Finished
-
-Every cloudinit document must contain a runcmd: section and that section must contain
-a call to the finished function.  The function takes one parameter, the workspace
-parameter.  A call to
-
-```
- - {{finished .}}
 ```
 
 is usually the last command in the runcmd section.  Remember it's currently mandatory.

--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -64,6 +64,11 @@ func prepareCreate(ctx context.Context, workloadName string, debug bool, update 
 		return nil, nil, fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 	}
 
+	err = wkld.generateCloudConfig(ws)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Error applying template to user-data")
+	}
+
 	return wkld, ws, nil
 }
 
@@ -111,7 +116,7 @@ func Create(ctx context.Context, workloadName string, debug bool, update bool, c
 		return err
 	}
 
-	err = buildISOImage(ctx, ws.instanceDir, wkld.userData, ws, debug)
+	err = buildISOImage(ctx, ws.instanceDir, wkld.mergedUserData, ws, debug)
 	if err != nil {
 		return err
 	}

--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -64,11 +64,6 @@ func prepareCreate(ctx context.Context, workloadName string, debug bool, update 
 		return nil, nil, fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 	}
 
-	err = wkld.generateCloudConfig(ws)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Error applying template to user-data")
-	}
-
 	return wkld, ws, nil
 }
 
@@ -100,14 +95,19 @@ func Create(ctx context.Context, workloadName string, debug bool, update bool, c
 		}
 	}()
 
-	err = wkld.save(ws)
-	if err != nil {
-		return errors.Wrap(err, "Unable to save instance state")
-	}
-
 	err = prepareSSHKeys(ctx, ws)
 	if err != nil {
 		return err
+	}
+
+	err = wkld.generateCloudConfig(ws)
+	if err != nil {
+		return errors.Wrap(err, "Error applying template to user-data")
+	}
+
+	err = wkld.save(ws)
+	if err != nil {
+		return errors.Wrap(err, "Unable to save instance state")
 	}
 
 	fmt.Printf("Downloading %s\n", wkld.spec.BaseImageName)

--- a/ccvm/ccvm_test.go
+++ b/ccvm/ccvm_test.go
@@ -105,11 +105,6 @@ func TestSystem(t *testing.T) {
 		t.Errorf("Instance not available via SSH: %v", err)
 	}
 
-	err = Run(ctx, "echo $PATH")
-	if err != nil {
-		t.Errorf("Failed to run test command via SSH")
-	}
-
 	err = Quit(ctx)
 	if err != nil {
 		t.Errorf("Failed to Restart instance: %v", err)

--- a/ccvm/mock_test.go
+++ b/ccvm/mock_test.go
@@ -36,6 +36,8 @@ vm:
   - host: 10022
     guest: 22
   mounts: []
+  disk_gib: 60
+hostname: singlevm
 `
 
 var mockVMSpec = types.VMSpec{

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -261,11 +261,6 @@ func endTaskFailFN(ws *workspace) string {
 	return fmt.Sprintf(failStr, ws.HTTPServerPort)
 }
 
-func finishedFN(ws *workspace) string {
-	const finishedStr = `curl -X PUT -d "FINISHED" 10.0.2.2:%d`
-	return fmt.Sprintf(finishedStr, ws.HTTPServerPort)
-}
-
 func proxyVarsFN(ws *workspace) string {
 	var buf bytes.Buffer
 	if ws.NoProxy != "" {

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -129,10 +129,10 @@ func prepareSSHKeys(ctx context.Context, ws *workspace) error {
 	_, pubKeyErr := os.Stat(ws.publicKeyPath)
 
 	if pubKeyErr != nil || privKeyErr != nil {
-		err := exec.CommandContext(ctx, "ssh-keygen",
-			"-f", ws.keyPath, "-t", "rsa", "-N", "").Run()
+		out, err := exec.CommandContext(ctx, "ssh-keygen",
+			"-f", ws.keyPath, "-t", "rsa", "-N", "").CombinedOutput()
 		if err != nil {
-			return errors.Wrap(err, "Unable to generate SSH key pair")
+			return errors.Wrapf(err, "Unable to generate SSH key pair: %s", string(out))
 		}
 	}
 

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -201,6 +201,12 @@ func (cc cloudConfig) merge(p cloudConfig) error {
 			continue
 		}
 
+		// If we can't merge (because value is nil) copy parent.
+		if !reflect.ValueOf(cc[k]).IsValid() {
+			cc[k] = v
+			continue
+		}
+
 		// else merge slices and maps
 		switch reflect.ValueOf(v).Type().Kind() {
 		case reflect.Slice:
@@ -214,6 +220,7 @@ func (cc cloudConfig) merge(p cloudConfig) error {
 			// update the top-level map (cc) for the current key (k) with the temporary slice (s)
 			reflect.ValueOf(cc).SetMapIndex(reflect.ValueOf(k), s)
 		case reflect.Map:
+
 			// first level merging only
 			if reflect.ValueOf(cc[k]).Type() != reflect.ValueOf(v).Type() {
 				return fmt.Errorf("Types of merged maps not equal for: %s", k)

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -294,6 +294,13 @@ func (wkld *workload) generateCloudConfig(ws *workspace) error {
 		return errors.Wrap(err, "Error parsing workload")
 	}
 
+	// remove empty top levels from the earlier parse
+	for k, v := range data {
+		if v == nil {
+			delete(data, k)
+		}
+	}
+
 	finishedStr := fmt.Sprintf(`curl -X PUT -d "FINISHED" 10.0.2.2:%d`,
 		ws.HTTPServerPort)
 	if v, ok := data["runcmd"]; ok {
@@ -302,13 +309,6 @@ func (wkld *workload) generateCloudConfig(ws *workspace) error {
 		data["runcmd"] = runcmds
 	} else {
 		data["runcmd"] = []string{finishedStr}
-	}
-
-	// remove empty top levels from the earlier parse
-	for k, v := range data {
-		if v == nil {
-			delete(data, k)
-		}
 	}
 
 	output, err := yaml.Marshal(data)

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -297,6 +297,13 @@ func (wkld *workload) generateCloudConfig(ws *workspace) error {
 		data["runcmd"] = []string{finishedStr}
 	}
 
+	// remove empty top levels from the earlier parse
+	for k, v := range data {
+		if v == nil {
+			delete(data, k)
+		}
+	}
+
 	output, err := yaml.Marshal(data)
 	if err != nil {
 		return errors.Wrap(err, "Error marshalling cloud-config")

--- a/ccvm/workload_test.go
+++ b/ccvm/workload_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/intel/ccloudvm/types"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -171,5 +172,219 @@ func TestRestoreWorkload(t *testing.T) {
 				defaultHostname, workload.spec.Hostname)
 		}
 
+	}
+}
+
+var level0Document = `
+base_image_url: https://mirror.us-midwest-1.nexcess.net/fedora/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+base_image_name: Fedora 27
+needs_nested_vm: true
+...
+---
+base: value
+`
+
+var level1Document = `
+vm:
+  mem_mib: 128
+  cpus: 2
+  mounts:
+  - tag: hostgo
+    security_model: passthrough
+    path: /tmp
+inherits: level0
+...
+---
+#cloud-config
+seq:
+- command 1
+- command 2
+map:
+ key1: value1
+`
+
+var level2Document = `
+vm:
+  mem_mib: 256
+inherits: level1
+...
+---
+seq:
+- command 3
+map:
+  key2: value2
+extra: value
+`
+
+func level0spec() workloadSpec {
+	spec := workloadSpec{
+		BaseImageURL:  "https://mirror.us-midwest-1.nexcess.net/fedora/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2",
+		BaseImageName: "Fedora 27",
+		NeedsNestedVM: true,
+		VM:            defaultVMSpec(),
+		WorkloadName:  "level0",
+		Hostname:      "singlevm",
+	}
+
+	spec.ensureSSHPortMapping()
+
+	return spec
+}
+
+func level1spec() workloadSpec {
+	spec := level0spec()
+	spec.VM.MemMiB = 128
+	spec.VM.CPUs = 2
+	spec.VM.Mounts = []types.Mount{
+		{
+			Tag:           "hostgo",
+			SecurityModel: "passthrough",
+			Path:          "/tmp",
+		},
+	}
+	spec.Inherits = "level0"
+	spec.WorkloadName = "level1"
+
+	return spec
+}
+
+func level2spec() workloadSpec {
+	spec := level1spec()
+	spec.VM.MemMiB = 256
+	spec.Inherits = "level1"
+	spec.WorkloadName = "level2"
+
+	return spec
+}
+
+var level0cloudConfig = `#cloud-config
+base: value
+`
+
+var level1cloudConfig = `#cloud-config
+base: value
+map:
+  key1: value1
+seq:
+- command 1
+- command 2
+`
+
+var level2cloudConfig = `#cloud-config
+base: value
+extra: value
+map:
+  key1: value1
+  key2: value2
+seq:
+- command 1
+- command 2
+- command 3
+`
+
+func TestWorkloadInheritance(t *testing.T) {
+	workloads := []struct {
+		body        string
+		name        string
+		expected    workloadSpec
+		cloudConfig string
+	}{
+		{
+			level0Document,
+			"level0",
+			level0spec(),
+			level0cloudConfig,
+		},
+		{
+			level1Document,
+			"level1",
+			level1spec(),
+			level1cloudConfig,
+		},
+		{
+			level2Document,
+			"level2",
+			level2spec(),
+			level2cloudConfig,
+		},
+	}
+
+	ccvmDir, err := ioutil.TempDir("", "ccloudvm-tests-")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(ccvmDir); err != nil {
+			t.Errorf("Failed to remove %s : %v", ccvmDir, err)
+		}
+	}()
+
+	var ws *workspace
+	for i := range workloads {
+		ws, err = createMockWorkSpaceWithWorkload(workloads[i].body, workloads[i].name, ccvmDir)
+		if err != nil {
+			t.Errorf("Failed to create mock workload: %v", err)
+			break
+		}
+	}
+
+	if err != nil {
+		t.Fatalf("Error populating mock workloads: %v", err)
+	}
+
+	for i := range workloads {
+		wkld, err := createWorkload(context.TODO(), ws, workloads[i].name)
+		if err != nil {
+			t.Fatalf("Error creating workloads: %v", err)
+		}
+
+		if !reflect.DeepEqual(wkld.spec, workloads[i].expected) {
+			t.Fatalf("Created workload not as expected: %s", workloads[i].name)
+		}
+
+		err = wkld.generateCloudConfig(ws)
+		if err != nil {
+			t.Fatalf("Error generating cloud config data: %v", err)
+		}
+
+		if string(wkld.mergedUserData) != workloads[i].cloudConfig {
+			t.Fatalf("Merged data doesn't match expected: %s vs %s", string(wkld.mergedUserData), workloads[i].cloudConfig)
+		}
+	}
+}
+
+var emptyWorkloadDocument = `
+...
+---
+`
+
+func TestBaseWorkload(t *testing.T) {
+	ccvmDir, err := ioutil.TempDir("", "ccloudvm-tests-")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(ccvmDir); err != nil {
+			t.Errorf("Failed to remove %s : %v", ccvmDir, err)
+		}
+	}()
+
+	ws, err := createMockWorkSpaceWithWorkload(emptyWorkloadDocument, "", ccvmDir)
+	if err != nil {
+		t.Fatalf("Failed to create mock workload: %v", err)
+	}
+
+	wkld, err := createWorkload(context.Background(), ws, "")
+	if err != nil {
+		t.Fatalf("Error creating workloads: %v", err)
+	}
+
+	defaultWorkload := defaultWorkload()
+	defaultWorkload.spec.ensureSSHPortMapping()
+
+	if !reflect.DeepEqual(defaultWorkload, wkld) {
+		t.Fatalf("Default workload expected")
 	}
 }

--- a/ccvm/workload_test.go
+++ b/ccvm/workload_test.go
@@ -220,6 +220,23 @@ runcmd:
 - command 2
 `
 
+// empty runcmd in final
+var invalidWorkload1 = `
+inherits: level0
+...
+---
+runcmd:
+`
+
+// empty runcmd in parent
+var invalidWorkload2 = `
+inherits: invalid1
+...
+---
+runcmd:
+  - test
+`
+
 func level0spec() workloadSpec {
 	spec := workloadSpec{
 		BaseImageURL:  "https://mirror.us-midwest-1.nexcess.net/fedora/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2",
@@ -261,6 +278,22 @@ func level2spec() workloadSpec {
 	return spec
 }
 
+func invalid1spec() workloadSpec {
+	spec := level0spec()
+	spec.Inherits = "level0"
+	spec.WorkloadName = "invalid1"
+
+	return spec
+}
+
+func invalid2spec() workloadSpec {
+	spec := invalid1spec()
+	spec.Inherits = "invalid1"
+	spec.WorkloadName = "invalid2"
+
+	return spec
+}
+
 var level0cloudConfig = `#cloud-config
 base: value
 runcmd:
@@ -295,6 +328,19 @@ seq:
 - command 3
 `
 
+var invalid1cloudConfig = `#cloud-config
+base: value
+runcmd:
+- curl -X PUT -d "FINISHED" 10.0.2.2:0
+`
+
+var invalid2cloudConfig = `#cloud-config
+base: value
+runcmd:
+- test
+- curl -X PUT -d "FINISHED" 10.0.2.2:0
+`
+
 func TestWorkloadInheritance(t *testing.T) {
 	workloads := []struct {
 		body        string
@@ -319,6 +365,18 @@ func TestWorkloadInheritance(t *testing.T) {
 			"level2",
 			level2spec(),
 			level2cloudConfig,
+		},
+		{
+			invalidWorkload1,
+			"invalid1",
+			invalid1spec(),
+			invalid1cloudConfig,
+		},
+		{
+			invalidWorkload2,
+			"invalid2",
+			invalid2spec(),
+			invalid2cloudConfig,
 		},
 	}
 

--- a/ccvm/workload_test.go
+++ b/ccvm/workload_test.go
@@ -199,6 +199,8 @@ inherits: level0
 seq:
 - command 1
 - command 2
+runcmd:
+- command 1
 map:
  key1: value1
 `
@@ -214,6 +216,8 @@ seq:
 map:
   key2: value2
 extra: value
+runcmd:
+- command 2
 `
 
 func level0spec() workloadSpec {
@@ -259,12 +263,17 @@ func level2spec() workloadSpec {
 
 var level0cloudConfig = `#cloud-config
 base: value
+runcmd:
+- curl -X PUT -d "FINISHED" 10.0.2.2:0
 `
 
 var level1cloudConfig = `#cloud-config
 base: value
 map:
   key1: value1
+runcmd:
+- command 1
+- curl -X PUT -d "FINISHED" 10.0.2.2:0
 seq:
 - command 1
 - command 2
@@ -276,6 +285,10 @@ extra: value
 map:
   key1: value1
   key2: value2
+runcmd:
+- command 1
+- command 2
+- curl -X PUT -d "FINISHED" 10.0.2.2:0
 seq:
 - command 1
 - command 2
@@ -349,7 +362,10 @@ func TestWorkloadInheritance(t *testing.T) {
 		}
 
 		if string(wkld.mergedUserData) != workloads[i].cloudConfig {
-			t.Fatalf("Merged data doesn't match expected: %s vs %s", string(wkld.mergedUserData), workloads[i].cloudConfig)
+			t.Fatalf("Merged data doesn't match expected for %s: %s vs %s",
+				workloads[i].name,
+				string(wkld.mergedUserData),
+				workloads[i].cloudConfig)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,7 +34,6 @@ var rootCmd = &cobra.Command{
 // Execute is the entry into the cmd package from the main package.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -191,3 +191,24 @@ func (in *VMSpec) SSHPort() (int, error) {
 	}
 	return 0, fmt.Errorf("No SSH port configured")
 }
+
+// Merge from a parent spec into the current spec
+func (in *VMSpec) Merge(parent *VMSpec) {
+	if in.MemMiB == 0 {
+		in.MemMiB = parent.MemMiB
+	}
+
+	if in.CPUs == 0 {
+		in.CPUs = parent.CPUs
+	}
+	if in.DiskGiB == 0 {
+		in.DiskGiB = parent.DiskGiB
+	}
+	if in.Qemuport == 0 {
+		in.Qemuport = parent.Qemuport
+	}
+
+	in.MergeMounts(parent.Mounts)
+	in.MergePorts(parent.PortMappings)
+	in.MergeDrives(parent.Drives)
+}

--- a/workloads/artful.yaml
+++ b/workloads/artful.yaml
@@ -51,7 +51,7 @@ runcmd:
  - {{endTaskCheck $}}
 {{end}}
 
- - {{finished .}}
+
 
 users:
   - name: {{.User}}

--- a/workloads/ciao-fedora25.yaml
+++ b/workloads/ciao-fedora25.yaml
@@ -191,9 +191,6 @@ runcmd:
  - echo "export GOPATH={{template "GOPATH" . }}" >> /home/{{.User}}/.profile
  - echo "export PATH=$PATH:{{template "GOPATH" . }}/bin:/usr/local/go/bin" >> /home/{{.User}}/.profile
  - echo "source /home/{{.User}}/.profile" >> /home/{{.User}}/.bashrc
-
-
- - {{finished .}}
   
 users:
   - name: {{.User}}

--- a/workloads/ciao.yaml
+++ b/workloads/ciao.yaml
@@ -194,8 +194,6 @@ runcmd:
  - echo "export GOPATH={{template "GOPATH" . }}" >> /home/{{.User}}/.profile
  - echo "export PATH=$PATH:{{template "GOPATH" . }}/bin:/usr/local/go/bin" >> /home/{{.User}}/.profile
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"

--- a/workloads/clearcontainers-2.x.yaml
+++ b/workloads/clearcontainers-2.x.yaml
@@ -186,8 +186,6 @@ runcmd:
  - {{endTaskCheck .}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -236,8 +236,6 @@ runcmd:
  - {{endTaskCheck .}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"

--- a/workloads/fedora25.yaml
+++ b/workloads/fedora25.yaml
@@ -51,8 +51,6 @@ runcmd:
  - {{endTaskCheck $}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     gecos: CC Demo User

--- a/workloads/fedora27.yaml
+++ b/workloads/fedora27.yaml
@@ -51,8 +51,6 @@ runcmd:
  - {{endTaskCheck $}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"

--- a/workloads/semaphore.yaml
+++ b/workloads/semaphore.yaml
@@ -57,8 +57,6 @@ runcmd:
  - {{endTaskCheck $}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"

--- a/workloads/xenial.yaml
+++ b/workloads/xenial.yaml
@@ -51,8 +51,6 @@ runcmd:
  - {{endTaskCheck $}}
 {{end}}
 
- - {{finished .}}
-
 users:
   - name: {{.User}}
     uid: "{{.UID}}"


### PR DESCRIPTION
Implement and test workload inheritance allowing a workload
specification to inherit the previous workload specification.
Inheritance of cloud-config data will follow in a later patch.

The most significant part of this change is that workload defaults are
now not injected as part of unmarshal but insteat in a default
specification that is always merged in.

The SSH port mapping however is special cased (as before) to ensure that
it is always mapped to allow ccloudvm connectivity.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>