### PR TITLE
Fix the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,6 @@ if it fails.
 Reporting a failure back to ccloudvm does not cause the create command to exit.  The
 failure is presented to the user and the setup of the VM continues.
 
-```
-
-is usually the last command in the runcmd section.  Remember it's currently mandatory.
-
 ### Automatically mounting shared folders
 
 As previously mentioned mounts specified in the instance data document will only


### PR DESCRIPTION
The formatting of the README.md document was broken  half way
through.  This commit fixes the issue.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>