### PR TITLE
Support Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-    - 1.8
     - 1.9
+    - "1.10"
     - tip
 
 go_import_path: github.com/intel/ccloudvm

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pre-shipped or user supplied annotated cloud-init files.
 
 All you need to have installed on your machine is:
 
-- Go 1.8 or greater
+- Go 1.9 or greater.
 
 The installation instructions for the latest version of Go can be
 found [here](https://golang.org/doc/install).  Once installed, ensure


### PR DESCRIPTION
And remove official support for Go 1.8, even though ccloudvm probably
still builds with 1.8.

Fixes: https://github.com/intel/ccloudvm/issues/59

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>