### PR TITLE
Prep work for supporting Clearlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ fields are currently defined:
 - base_image_url  : The URL of the qcow2 image upon which instances of the workload should be based.
 - base_image_name : Friendly name for the base image.  This is optional.
 - vm              : Contains information about creating and booting the instance.
+- bios            : A URI (file, http, or https) pointing to the BIOS file, e.g, OVMF.fd, with which to boot the image.  Should be omitted for legacy boots.
 
 The vm field supports a number of child fields.
 

--- a/ccvm/download_test.go
+++ b/ccvm/download_test.go
@@ -67,7 +67,7 @@ func startTestHTTPServer(wg *sync.WaitGroup) (*http.Server, string, error) {
 
 func testDownloadSingle(ctx context.Context, t *testing.T, downloadCh chan<- downloadRequest, addr, ccvmDir string) {
 	path, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-		"http://"+addr+"/download/one", func(p progress) {})
+		"http://"+addr+"/download/one", func(bool, progress) {})
 	if err != nil {
 		t.Errorf("Failed to download file : %v", err)
 	}
@@ -83,7 +83,7 @@ func testDownloadDouble(ctx context.Context, t *testing.T, downloadCh chan<- dow
 	for _, ch := range pathChans {
 		go func(ch chan string) {
 			path, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-				"http://"+addr+"/download/double", func(p progress) {})
+				"http://"+addr+"/download/double", func(bool, progress) {})
 			if err != nil {
 				t.Errorf("Failed to download file : %v", err)
 			}
@@ -110,7 +110,7 @@ func testDownloadDoubleDifferent(ctx context.Context, t *testing.T, downloadCh c
 		go func(ch chan string, i int) {
 			url := fmt.Sprintf("http://%s/download/double-%d", addr, i)
 			path, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-				url, func(p progress) {})
+				url, func(bool, progress) {})
 			if err != nil {
 				t.Errorf("Failed to download file : %v", err)
 			}
@@ -143,7 +143,7 @@ func testDownloadCancelSingle(ctx context.Context, t *testing.T, downloadCh chan
 	cancel()
 	go func() {
 		path, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-			"http://"+addr+"/download/singlecancel", func(p progress) {})
+			"http://"+addr+"/download/singlecancel", func(bool, progress) {})
 		ch <- dld{path, err}
 	}()
 	res := <-ch
@@ -173,7 +173,7 @@ func testDownloadCancelOneOfTwo(ctx context.Context, t *testing.T, downloadCh ch
 	for _, p := range params {
 		go func(ctx context.Context, ch chan dld) {
 			path, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-				"http://"+addr+"/download/oneoftwo", func(p progress) {})
+				"http://"+addr+"/download/oneoftwo", func(bool, progress) {})
 			ch <- dld{path, err}
 		}(p.ctx, p.ch)
 	}
@@ -194,7 +194,7 @@ func testDownloadCancelOneOfTwo(ctx context.Context, t *testing.T, downloadCh ch
 
 func testDownloadError(ctx context.Context, t *testing.T, downloadCh chan<- downloadRequest, addr, ccvmDir string) {
 	_, err := downloadFile(ctx, downloadCh, http.DefaultTransport.(*http.Transport),
-		"http://"+addr+"/error", func(p progress) {})
+		"http://"+addr+"/error", func(bool, progress) {})
 	if err == nil {
 		t.Errorf("Expected download to fail")
 	}

--- a/ccvm/instance.go
+++ b/ccvm/instance.go
@@ -42,6 +42,7 @@ type workloadSpec struct {
 	BaseImageName string       `yaml:"base_image_name"`
 	WorkloadName  string       `yaml:"workload"`
 	NeedsNestedVM bool         `yaml:"needs_nested_vm"`
+	BIOS          string       `yaml:"bios"`
 	VM            types.VMSpec `yaml:"vm"`
 	Inherits      string       `yaml:"inherits"`
 }

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -50,6 +50,10 @@ func bootVM(ctx context.Context, ws *workspace, name string, in *types.VMSpec) e
 		return fmt.Errorf("VM is already running")
 	}
 
+	BIOSPath := path.Join(ws.instanceDir, "BIOS")
+	if _, err := os.Stat(BIOSPath); err != nil {
+		BIOSPath = ""
+	}
 	vmImage := path.Join(ws.instanceDir, "image.qcow2")
 	isoPath := path.Join(ws.instanceDir, "config.iso")
 	memParam := fmt.Sprintf("%dM", in.MemMiB)
@@ -62,6 +66,10 @@ func bootVM(ctx context.Context, ws *workspace, name string, in *types.VMSpec) e
 		"-daemonize", "-enable-kvm", "-cpu", "host",
 		"-net", "nic,model=virtio",
 		"-device", "virtio-rng-pci",
+	}
+
+	if BIOSPath != "" {
+		args = append(args, "-bios", BIOSPath)
 	}
 
 	for i, m := range in.Mounts {

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -159,7 +159,8 @@ func serveLocalFile(ctx context.Context, downloadCh chan<- downloadRequest, tran
 	params := r.URL.Query()
 	URL := params.Get(urlParam)
 
-	path, err := downloadFile(ctx, downloadCh, transport, URL, func(progress) {})
+	path, err := downloadFile(ctx, downloadCh, transport, URL,
+		func(bool, progress) {})
 	if err != nil {
 		// May not be the correct error code but the error message is only going
 		// to end up in cloud-init's logs.

--- a/client/deps.go
+++ b/client/deps.go
@@ -19,6 +19,7 @@ package client
 import "github.com/ciao-project/ciao/osprepare"
 
 var ccloudvmClearDeps = []osprepare.PackageRequirement{
+	{BinaryName: "/usr/bin/unxz", PackageName: "os-core-update"},
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "cloud-control"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "cloud-control"},
 	{BinaryName: "/usr/bin/ssh", PackageName: "openssh-server"},
@@ -26,6 +27,7 @@ var ccloudvmClearDeps = []osprepare.PackageRequirement{
 }
 
 var ccloudvmFedoraDeps = []osprepare.PackageRequirement{
+	{BinaryName: "/usr/bin/unxz", PackageName: "xz"},
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
 	{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-img"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},
@@ -34,6 +36,7 @@ var ccloudvmFedoraDeps = []osprepare.PackageRequirement{
 }
 
 var ccloudvmUbuntuDeps = []osprepare.PackageRequirement{
+	{BinaryName: "/usr/bin/unxz", PackageName: "xz-utils"},
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
 	{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-utils"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},


### PR DESCRIPTION
This PR contains a number of preparatory PRs for getting ccloudvm ready to work with Clearlinux.  It

1. Adds support for .xz compressed backing images.
2. Adds support for specifying a BIOS file when booting an instance.  This is needed for EFI boot.
3. Outputs an ssh connection string when the --debug flag is passed to the create command.  This allows users to ssh into an inside which has failed to create properly due to a corrupted cloud-init file.
4. Fix the erroneous Downloading messages which were output even when ccloudvm was using a cached file rather than a backing image. 