### PR TITLE
Ensure 127.0.0.1 is part of the no_proxy env variable

### DIFF
--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/ciao-project/ciao/deviceinfo"
 	"github.com/intel/ccloudvm/types"
@@ -82,9 +83,20 @@ func prepareCreate(ctx context.Context, args *types.CreateArgs) (*workload, *wor
 	ws.Mounts = in.Mounts
 	ws.Hostname = args.Name
 	if ws.NoProxy != "" {
-		ws.NoProxy = fmt.Sprintf("%s,%s,10.0.2.2", ws.Hostname, ws.NoProxy)
+		split := strings.Split(ws.NoProxy, ",")
+		var i int
+		for i = 0; i < len(split); i++ {
+			if split[i] == "127.0.0.1" {
+				break
+			}
+		}
+		if i == len(split) {
+			split = append(split, "127.0.0.1")
+		}
+		split = append(split, ws.Hostname, "10.0.2.2")
+		ws.NoProxy = strings.Join(split, ",")
 	} else if ws.HTTPProxy != "" || ws.HTTPSProxy != "" {
-		ws.NoProxy = fmt.Sprintf("%s,10.0.2.2", ws.Hostname)
+		ws.NoProxy = fmt.Sprintf("%s,10.0.2.2,127.0.0.1", ws.Hostname)
 	}
 
 	ws.PackageUpgrade = "false"


### PR DESCRIPTION
This commit ensures that 127.0.0.1 is present in the
workspace.NoProxy field if proxies are enabled on the host.  The
chances are that if the host has proxies enabled, 127.0.0.1 will be
present in its no_proxy anyway, but we might as well make sure.  If
it is present, we'll take care not to add it twice.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>