### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ export PATH=$PATH:$(go env GOPATH)/bin
 Then, to create a new Ubuntu 16.04 VM, simply type
 
 ```
-$ go get github.com/intel/ccloudvm
+$ go get github.com/intel/ccloudvm/...
 $ ccloudvm setup
 $ ccloudvm create xenial
 ```


### PR DESCRIPTION
The build instructions for the README.md file were incorrect.  If you were
to execute the commands on a fresh install only the ccloudvm cli tool
would be built.  The systemd user service would not get built.  This commit
updates the build instructions to ensure that everything gets built.

Fixes: https://github.com/intel/ccloudvm/issues/74

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>