### PR TITLE
Introduce the copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,35 @@ $ ccloudvm create --mount hostgo,none,$HOME/go -port 10023-22 xenial
 changes the security model of the mount with the hostgo tag and makes the instance
 available via ssh on HOSTIP:10023.
 
+### copy \[instance-name\] src dest
+
+The copy command is used to copy files between the host and the guest.  Files
+can be transferred in both directions and it's also possible to recursively
+copy directories.  The instance name is optional if there is only one instance.
+Let's look at some examples.
+
+```
+$ ccloudvm copy local.conf local.conf
+```
+
+Copies the local.conf file in the user's current directory on the host
+to the user's home directory in the guest.
+
+```
+$ ccloudvm copy sad-nimue -r inc code/inc
+```
+
+Recursively copies the contents of the directory inc from the host's current
+directory to the ~/code/inc directory on the sad-nimue guest.
+
+Finally,
+
+```
+$ ccloudvm copy -t /var/log/cloud-init-output.log cloud-init-output.log
+```
+
+copies the log file from /var/log/cloud-init-output.log on the guest to the current
+host directory.
 
 ### delete \[instance-name\]
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,0 +1,50 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/intel/ccloudvm/client"
+	"github.com/spf13/cobra"
+)
+
+var recurse bool
+var host bool
+
+var copyCmd = &cobra.Command{
+	Use:   "copy",
+	Short: "Copy files between the host and the guest using scp",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancelFunc := getSignalContext()
+		defer cancelFunc()
+
+		var instanceName string
+		if len(args) >= 3 {
+			instanceName = args[0]
+			args = args[1:]
+		}
+
+		return client.Copy(ctx, instanceName, recurse, host, args[0], args[1])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(copyCmd)
+
+	copyCmd.Flags().BoolVarP(&recurse, "recurse", "r", false, "Recursively copy contents of a directory")
+	copyCmd.Flags().BoolVarP(&host, "to-host", "t", false, "Copy files from guest to host")
+}

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -11,6 +11,11 @@ function finish {
 	ccloudvm delete semaphore
     fi
 
+    if [ -f $tfile ]
+    then
+	rm $tfile
+    fi
+
     echo ""
     echo "=============================="
     if [[ $error_code -eq 0 ]]
@@ -129,6 +134,15 @@ echo ""
 instance_ip=$(ccloudvm status semaphore | sed '2q;d' | cut -d ":" -f 2 | xargs)
 
 http_proxy= curl http://$instance_ip:8000
+
+# Copy files between the host and the guest
+
+echo ""
+echo "===== Testing ccloudvm copy ====="
+echo ""
+
+tfile=$(mktemp /tmp/README.XXXXXXXXX)
+ccloudvm copy -t semaphore /etc/resolv.conf $tfile
 
 # Stop the VM
 


### PR DESCRIPTION
This PR adds a new command, copy, that can be used to transfer files between the host and the guests.  Files can be transferred in both directions and it's also possible to copy directories.