### PR TITLE
Add docker-xenial workload

### DIFF
--- a/workloads/ciao.yaml
+++ b/workloads/ciao.yaml
@@ -1,5 +1,5 @@
 ---
-inherits: xenial
+inherits: docker-xenial
 needs_nested_vm: true
 vm:
   mem_mib: 4000
@@ -30,9 +30,6 @@ write_files:
    path: /etc/update-motd.d/10-ciao-help-text
    permissions: '0755'
  - content: |
-     deb https://download.docker.com/linux/ubuntu xenial stable
-   path: /etc/apt/sources.list.d/docker.list
- - content: |
      deb http://apt.kubernetes.io/ kubernetes-xenial main
    path: /etc/apt/sources.list.d/kubernetes.list
 
@@ -55,27 +52,12 @@ runcmd:
 
  - rm /tmp/go1.9.linux-amd64.tar.gz
 
- - groupadd docker
- - sudo gpasswd -a {{.User}} docker
-
- - {{beginTask . "Installing apt-transport-https and ca-certificates" }}
- - {{template "ENV" .}}apt-get install apt-transport-https ca-certificates
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add docker GPG key" }}
- - {{template "ENV" .}}curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
- - {{endTaskCheck .}}
-
  - {{beginTask . "Add Google GPG key" }}
  - {{template "ENV" .}}curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
  - {{endTaskCheck .}}
 
  - {{beginTask . "Retrieving updated list of packages"}}
  - {{template "ENV" .}}apt-get update
- - {{endTaskCheck .}}
-
- - {{beginTask . "Installing Docker"}}
- - {{template "ENV" .}}apt-get install docker-ce -y
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing kubectl"}}

--- a/workloads/docker-xenial.yaml
+++ b/workloads/docker-xenial.yaml
@@ -1,0 +1,62 @@
+---
+inherits: xenial
+...
+---
+{{- define "ENV" -}}
+{{proxyVars .}}
+{{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}
+{{end}}
+#cloud-config
+{{- if len $.HTTPProxy }}
+write_files:
+ - content: |
+     [Service]
+     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
+   path: /etc/systemd/system/docker.service.d/http-proxy.conf
+{{- end}}
+packages:
+ - apt-transport-https
+ - ca-certificates
+ - curl
+ - software-properties-common
+
+runcmd:
+ - {{beginTask . "Add docker GPG key" }}
+ - {{template "ENV" .}}curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Adding docker repo"}}
+ - {{template "ENV" .}} sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Retrieving updated list of packages"}}
+ - {{template "ENV" .}}sudo apt-get update
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Install docker-ce"}}
+ - sudo apt-get install -y docker-ce
+ - {{endTaskCheck .}}
+
+ - {{beginTask . (printf "Adding user %s to the docker group" .User)}}
+ - sudo gpasswd -a {{.User}} docker
+ - {{endTaskCheck .}}
+
+{{- if len $.HTTPProxy }}
+ - {{beginTask . "Configuring docker proxies" }}
+ - mkdir /home/{{.User}}/.docker
+ - echo "{" >> /home/{{.User}}/.docker/config.json
+ - echo "  \"proxies\":" >> /home/{{.User}}/.docker/config.json
+ - echo "  {" >> /home/{{.User}}/.docker/config.json
+ - echo "    \"default\":" >> /home/{{.User}}/.docker/config.json
+ - echo "    {" >> /home/{{.User}}/.docker/config.json
+ - echo "      \"httpProxy\":\"{{.HTTPProxy}}\"," >> /home/{{.User}}/.docker/config.json
+ - echo "      \"httpsProxy\":\"{{.HTTPSProxy}}\"," >> /home/{{.User}}/.docker/config.json
+ - echo "      \"noProxy\":\"{{.NoProxy}}\"" >> /home/{{.User}}/.docker/config.json
+ - echo "    }" >> /home/{{.User}}/.docker/config.json
+ - echo "  }" >> /home/{{.User}}/.docker/config.json
+ - echo "}" >> /home/{{.User}}/.docker/config.json
+ - chown {{.User}}:{{.User}} -R /home/{{.User}}/.docker
+ - {{endTaskCheck .}}
+{{end}}
+
+...

--- a/workloads/xenial.yaml
+++ b/workloads/xenial.yaml
@@ -11,12 +11,6 @@ vm:
 {{end}}
 #cloud-config
 write_files:
-{{- if len $.HTTPProxy }}
- - content: |
-     [Service]
-     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
-   path: /etc/systemd/system/docker.service.d/http-proxy.conf
-{{- end}}
 {{with proxyEnv . 5}}
  - content: |
 {{.}}


### PR DESCRIPTION
Add a new workload called docker-xenial.  The old xenial workload has also been
modified to remove some docker specific proxy settings that didn't really
belong in this file.  Finally, the ciao workload has been updated so that it
inherits from docker-xenial, rather than just xenial.  This simplifies it a little
bit.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>