### PR TITLE
Update the clearcontainers-3.x workload

### DIFF
--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -39,20 +39,6 @@ write_files:
      printf "\n"
    path: /etc/update-motd.d/10-ciao-help-text
    permissions: '0755'
- - content: |
-     [Unit]
-      Description=OCI-based implementation of Kubernetes Container Runtime Interface
-      Documentation=https://github.com/kubernetes-incubator/cri-o
-
-      [Service]
-      ExecStart=/usr/bin/crio --debug
-      Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
-      Restart=on-failure
-      RestartSec=5
-
-      [Install]
-      WantedBy=multi-user.target
-   path: /etc/systemd/system/crio.service
 
 packages:
  - wget
@@ -82,22 +68,6 @@ runcmd:
  - {{beginTask . "Add Clear Containers OBS Repository "}}
  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"
  - {{template "ENV" .}}curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/Release.key | sudo apt-key add -
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add CRI-O OS dependency repo"}}
- - {{template "ENV" .}}sudo add-apt-repository "ppa:alexlarsson/flatpak"
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add CRI-O repo"}}
- - {{template "ENV" .}}sudo add-apt-repository "ppa:projectatomic/ppa"
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add K8S repo"}}
- - sudo sh -c "echo 'deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main' >> /etc/apt/sources.list.d/kubernetes.list"
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add Google GPG key"}}
- - {{template "ENV" .}}curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
  - {{endTaskCheck .}}
 
  - {{beginTask . "Retrieving updated list of packages"}}
@@ -130,34 +100,8 @@ runcmd:
  - {{template "ENV" .}}apt-get install build-essential python zlib1g-dev libcap-ng-dev libglib2.0-dev libpixman-1-dev libattr1-dev libcap-dev autoconf libtool libjson-glib-dev uuid-dev check bats libdevmapper-dev file apt-utils wget valgrind lcov libmnl-dev cppcheck libtap-formatter-html-perl -y
  - {{endTaskCheck .}}
 
- - {{beginTask . "Installing CRI-O dependencies"}}
- - {{template "ENV" .}}apt-get install -y socat libgpgme11 libostree-1-1
- - {{endTaskCheck .}}
-
- - {{beginTask . "Installing K8S"}}
- - {{template "ENV" .}}apt-get install -y kubelet=1.7.5-00 kubeadm=1.7.5-00 kubectl=1.7.5-00
- - {{template "ENV" .}}sudo apt-mark hold kubelet kubeadm kubectl
- - {{endTaskCheck .}}
-
- - {{beginTask . "Installing CRI-O"}}
- - {{template "ENV" .}}apt-get install -y cri-o
- - {{endTaskCheck .}}
-
  - {{beginTask . "Auto removing unused development components"}}
  - {{template "ENV" .}}apt-get auto-remove -y
- - {{endTaskCheck .}}
-
- - {{beginTask . "Configuring CRIO for Clear Containers"}}
- - sudo sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/bin\/cc-runtime"/' "/etc/crio/crio.conf"
- - {{endTaskCheck .}}
-
- - {{beginTask . "Configuring K8S for CRIO"}}
- - sudo sed -i '/KUBELET_CADVISOR_ARGS/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=/var/run/crio.sock --runtime-request-timeout=30m"' "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
- - {{endTaskCheck .}}
-
- - {{beginTask . "Start CRI-O daemon"}}
- - sudo systemctl enable crio
- - sudo systemctl start crio
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing Go development utils"}}

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -31,10 +31,10 @@ write_files:
      printf "Your go code is at {{template "GOPATH" .}}\n"
      printf "You can also edit your code on your host system \n"
      printf "To build cc-runtime from sources \n"
-     printf "go get -d github.com/clearcontainers/runtime... \n"
+     printf "go get -d github.com/clearcontainers/runtime/... \n"
      printf "cd {{template "GOPATH" .}}/src/github.com/clearcontainers/runtime \n"
      printf "make build-cc-system\n"
-     printf "sudo -E PATH=$PATH make install-cc-system \n"
+     printf "sudo -E PATH=\$PATH make install-cc-system \n"
      printf "\n"
      printf "\n"
    path: /etc/update-motd.d/10-ciao-help-text
@@ -121,5 +121,7 @@ runcmd:
  - sudo -u {{.User}} git config --global user.email {{.GitEmail}}
  - {{endTaskCheck .}}
 {{end}}
+
+ - echo "export PATH=\$PATH:{{template "GOPATH" . }}/bin:/usr/local/go/bin" >> /home/{{.User}}/.profile
 
 ...

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -54,6 +54,9 @@ write_files:
       WantedBy=multi-user.target
    path: /etc/systemd/system/crio.service
 
+packages:
+ - wget
+
 runcmd:
 
  - rm /etc/update-motd.d/10-help-text /etc/update-motd.d/51-cloudguest
@@ -107,9 +110,8 @@ runcmd:
 
  - {{beginTask . "Start Clear Containers Runtime"}}
  - sudo systemctl daemon-reload
+ - sudo systemctl enable docker.service
  - sudo systemctl restart docker
- - sudo systemctl enable cc-proxy.socket
- - sudo systemctl start cc-proxy.socket
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing GCC"}}

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -22,7 +22,7 @@ write_files:
  - content: |
      [Service]
      ExecStart=
-     ExecStart=/usr/bin/dockerd -D --add-runtime cor=/usr/bin/cc-runtime --default-runtime=cor
+     ExecStart=/usr/bin/dockerd -D --add-runtime cc-runtime=/usr/bin/cc-runtime --default-runtime=cc-runtime
    path: /etc/systemd/system/docker.service.d/clr-containers.conf
  - content: |
      #!/bin/sh

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -70,14 +70,14 @@ runcmd:
  - echo "PATH=\"$PATH:/usr/local/go/bin:{{template "GOPATH" .}}/bin\""  >> /etc/environment
 
  - {{beginTask . "Downloading Go" }}
- - {{download . "https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz" "/tmp/go1.8.3.linux-amd64.tar.gz"}}
+ - {{download . "https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz" "/tmp/go1.9.2.linux-amd64.tar.gz"}}
  - {{endTaskCheck .}}
 
  - {{beginTask . "Unpacking Go" }}
- - tar -C /usr/local -xzf /tmp/go1.8.3.linux-amd64.tar.gz
+ - tar -C /usr/local -xzf /tmp/go1.9.2.linux-amd64.tar.gz
  - {{endTaskCheck .}}
  
- - rm /tmp/go1.8.3.linux-amd64.tar.gz
+ - rm /tmp/go1.9.2.linux-amd64.tar.gz
 
  - {{beginTask . "Add Clear Containers OBS Repository "}}
  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -91,7 +91,11 @@ runcmd:
 
  - {{beginTask . "Add K8S repo"}}
  - sudo sh -c "echo 'deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main' >> /etc/apt/sources.list.d/kubernetes.list"
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Add Google GPG key"}}
  - {{template "ENV" .}}curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+ - {{endTaskCheck .}}
 
  - {{beginTask . "Retrieving updated list of packages"}}
  - {{template "ENV" .}}sudo apt-get update

--- a/workloads/clearcontainers-3.x.yaml
+++ b/workloads/clearcontainers-3.x.yaml
@@ -1,7 +1,5 @@
 ---
-base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
-base_image_name: Ubuntu 16.04
-hostname: singlevm
+inherits: docker-xenial
 needs_nested_vm: true
 vm:
   mem_mib: 4000
@@ -21,17 +19,6 @@ vm:
 {{ define "GOPATH" }}{{with .GoPath}}{{$.MountPath "hostgo"}}{{else}}/home/{{.User}}/go{{end}}{{end}}
 #cloud-config
 write_files:
-{{- if len $.HTTPProxy }}
- - content: |
-     [Service]
-     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
-   path: /etc/systemd/system/docker.service.d/http-proxy.conf
-{{- end}}
-{{with proxyEnv . 5}}
- - content: |
-{{.}}
-   path: /etc/environment
-{{end}}
  - content: |
      [Service]
      ExecStart=
@@ -66,39 +53,9 @@ write_files:
       [Install]
       WantedBy=multi-user.target
    path: /etc/systemd/system/crio.service
- - content: |
-     deb https://apt.dockerproject.org/repo ubuntu-xenial main
-   path: /etc/apt/sources.list.d/docker.list
-
-apt:
-{{- if len $.HTTPProxy }}
-  proxy: "{{$.HTTPProxy}}"
-{{- end}}
-{{- if len $.HTTPSProxy }}
-  https_proxy: "{{$.HTTPSProxy}}"
-{{- end}}
-package_upgrade: {{with .PackageUpgrade}}{{.}}{{else}}true{{end}}
 
 runcmd:
- - {{beginTask . "Booting VM"}}
- - {{endTaskOk . }}
 
- - {{beginTask . (printf "Adding %s to /etc/hosts" .Hostname) }}
- - echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts
- - {{endTaskCheck .}}
-
-{{range .Mounts}}
- - mkdir -p {{.Path}}
- - sudo chown {{$.User}}:{{$.User}} {{.Tag}}
- - echo "{{.Tag}} {{.Path}} 9p x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L 0 0" >> /etc/fstab
-{{end}}
-{{range .Mounts}}
- - {{beginTask $ (printf "Mounting %s" .Path) }}
- - mount {{.Path}}
- - {{endTaskCheck $}}
-{{end}}
-
- - chown {{.User}}:{{.User}} /home/{{.User}}
  - rm /etc/update-motd.d/10-help-text /etc/update-motd.d/51-cloudguest
  - rm /etc/update-motd.d/90-updates-available
  - rm /etc/legal
@@ -118,21 +75,6 @@ runcmd:
  - {{endTaskCheck .}}
  
  - rm /tmp/go1.8.3.linux-amd64.tar.gz
-
- - groupadd docker
- - sudo gpasswd -a {{.User}} docker
-
- - {{beginTask . "Installing apt-transport-https and ca-certificates" }}
- - {{template "ENV" .}}sudo apt-get -y install  apt-transport-https ca-certificates
- - {{endTaskCheck .}}
-
- - {{beginTask . "Add docker GPG key" }}
- - {{template "ENV" .}}curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
- - {{endTaskCheck .}}
-
- - {{beginTask . "Adding docker repo"}}
- - {{template "ENV" .}} sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
- - {{endTaskCheck .}}
 
  - {{beginTask . "Add Clear Containers OBS Repository "}}
  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"
@@ -159,10 +101,6 @@ runcmd:
  - {{template "ENV" .}}sudo apt-get install -y cc-runtime cc-proxy cc-shim
  - {{endTaskCheck .}}
 
- - {{beginTask . "Installing Docker"}}
- - {{template "ENV" .}}sudo apt-get install -y --allow-downgrades --allow-unauthenticated docker-engine=1.12.1-0~xenial
- - {{endTaskCheck .}}
-
  - {{beginTask . "Start Clear Containers Runtime"}}
  - sudo systemctl daemon-reload
  - sudo systemctl restart docker
@@ -180,10 +118,6 @@ runcmd:
 
  - {{beginTask . "Installing QEMU" }}
  - {{template "ENV" .}}apt-get install qemu-system-x86 -y
- - {{endTaskCheck .}}
-
- - {{beginTask . "Installing xorriso"}}
- - {{template "ENV" .}}apt-get install xorriso -y
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing Clear Containers development tools"}}
@@ -238,14 +172,4 @@ runcmd:
  - {{endTaskCheck .}}
 {{end}}
 
-users:
-  - name: {{.User}}
-    uid: "{{.UID}}"
-    gid: "{{.GID}}"
-    gecos: CC Demo User
-    lock-passwd: true
-    shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-authorized-keys:
-    - {{.PublicKey}}
 ...


### PR DESCRIPTION
This commit makes a number of changes to the clearcontainers-3.x workload.

1. The workload now derives from docker-xenial, which allows us to remove a lot of code.  The workload also benefits from the fact that docker-xenial installs the latest version of docker-ce and sets up proxies correctly inside the containers as well as outside.
2. Made the installation instructions for cc3.x match the instructions on the CC wiki.
3. Update the version of Go used.
4. Removed CRI-O and K8S.  The CRI-O installation didn't work anyway.