### PR TITLE
Make the name generator more random

### DIFF
--- a/ccvm/name.go
+++ b/ccvm/name.go
@@ -108,8 +108,7 @@ func init() {
 	}
 	for i := 0; i < len(nameGenerator.indicies); i++ {
 		r1 := nameGenerator.rand.Int() % len(nameGenerator.indicies)
-		r2 := nameGenerator.rand.Int() % len(nameGenerator.indicies)
-		nameGenerator.indicies[r1], nameGenerator.indicies[r2] = nameGenerator.indicies[r2], nameGenerator.indicies[r1]
+		nameGenerator.indicies[r1], nameGenerator.indicies[i] = nameGenerator.indicies[i], nameGenerator.indicies[r1]
 	}
 }
 


### PR DESCRIPTION
The random shuffle algorithm used by the name generator was buggy.
It swapped N pairs of randomly selected names, where N is the total
number of names.  What it should have been doing was swapping each
name with a randomly chosen name.  This makes it much more likely
that each name will be moved from its original position in the
slice of possible names.  There should be fewer alarmed-agravains
from now on.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>