### PR TITLE
Fix workload search

### DIFF
--- a/ccvm/ccvm_test.go
+++ b/ccvm/ccvm_test.go
@@ -24,7 +24,9 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -125,6 +127,15 @@ func setProxies(args *types.CreateArgs) error {
 	return nil
 }
 
+func setGoPath(args *types.CreateArgs) error {
+	goPathBytes, err := exec.Command("go", "env", "GOPATH").Output()
+	if err != nil {
+		return errors.Wrap(err, "Unable to determine GOPATH")
+	}
+	args.GoPath = strings.TrimSpace(string(goPathBytes))
+	return nil
+}
+
 func createDownloader() (*downloader, error) {
 	d := &downloader{}
 	home := os.Getenv("HOME")
@@ -188,6 +199,11 @@ func TestSystem(t *testing.T) {
 	err := setProxies(createArgs)
 	if err != nil {
 		t.Fatalf("Unable to set proxies: %v", err)
+	}
+
+	err = setGoPath(createArgs)
+	if err != nil {
+		t.Fatalf("Unable to set GOPath: %v", err)
 	}
 
 	resultCh := make(chan interface{})

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -179,7 +179,9 @@ func loadWorkloadData(ctx context.Context, ws *workspace, workloadName string, t
 		return wkld, nil
 	}
 
-	p, err := build.Default.Import(ccloudvmPkg, "", build.FindOnly)
+	bld := build.Default
+	bld.GOPATH = ws.GoPath
+	p, err := bld.Import(ccloudvmPkg, "", build.FindOnly)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to locate ccloudvm workload directory")
 	}


### PR DESCRIPTION
ccloudvm was unable to find the workload directory if the directory
resided in a GOPATH that was not the default.  The reason was that
the search is performed using the environment variables of the service
and not that of the client.  Although the client's GOPATH is passed
into the service it was not being used when searching for workloads.
This has now been fixed:

Fixes: https://github.com/intel/ccloudvm/issues/87

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>