### PR TITLE
Add bionic workload

### DIFF
--- a/workloads/bionic.yaml
+++ b/workloads/bionic.yaml
@@ -1,0 +1,66 @@
+---
+base_image_url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+base_image_name: Ubuntu 18.10
+vm:
+  disk_gib: 16
+...
+---
+{{- define "ENV" -}}
+{{proxyVars .}}
+{{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}
+{{end}}
+#cloud-config
+write_files:
+{{- if len $.HTTPProxy }}
+ - content: |
+     [Service]
+     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
+   path: /etc/systemd/system/docker.service.d/http-proxy.conf
+{{- end}}
+{{with proxyEnv . 5}}
+ - content: |
+{{.}}
+   path: /etc/environment
+{{end}}
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+package_upgrade: {{with .PackageUpgrade}}{{.}}{{else}}false{{end}}
+
+runcmd:
+ - {{beginTask . "Booting VM"}}
+ - {{endTaskOk . }}
+
+ - {{beginTask . (printf "Adding %s to /etc/hosts" .Hostname) }}
+ - echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts
+ - {{endTaskCheck .}}
+
+{{range .Mounts}}
+ - mkdir -p {{.Path}}
+ - sudo chown {{$.User}}:{{$.User}} {{.Tag}}
+ - echo "{{.Tag}} {{.Path}} 9p x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L 0 0" >> /etc/fstab
+{{end}}
+{{range .Mounts}}
+ - {{beginTask $ (printf "Mounting %s" .Path) }}
+ - mount {{.Path}}
+ - {{endTaskCheck $}}
+{{end}}
+
+
+
+users:
+  - name: {{.User}}
+    uid: "{{.UID}}"
+    gid: "{{.GID}}"
+    gecos: CIAO Demo User
+    lock-passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - {{.PublicKey}}
+...


### PR DESCRIPTION
This commit adds a basic bionic (Ubuntu 18.04) workload similar to
the xenial and artful workloads.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>