### PR TITLE
Disable service timeout when not using systemd

### DIFF
--- a/ccvm/server.go
+++ b/ccvm/server.go
@@ -525,7 +525,7 @@ func (s *ccvmService) processAction(action interface{}) {
 		}
 		delete(s.transactions, int(a))
 		if len(s.transactions) == 0 {
-			if s.shutdownTimer == nil {
+			if s.shutdownTimer == nil && systemd {
 				shutdownIn := time.Minute
 				s.shutdownTimer = time.NewTimer(shutdownIn)
 				s.cases[TimeChIndex].Chan = reflect.ValueOf(s.shutdownTimer.C)


### PR DESCRIPTION
The ccvm service starts a timer when it has completed executing its last
command and its command queue is empty.  The timer lasts for one minute
and if no new commands are received during this minute, the service
shuts down.  This makes sense when using systemd as the service will be
automically restarted to service any new commands by systemd socket
activation.  However, when running ccvm without systemd there's nothing
to restart it, so it doesn't make sense to shut it down when its idle.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>