### PR TITLE
Switch go linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+linters:
+  enable:
+    - gofmt
+    - gocyclo
+    - misspell
+linters-settings:
+  gocyclo:
+    min-complexity: 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
 
 go:
-    - 1.9
-    - "1.10"
+    - "1.11"
+    - "1.12"
     - tip
+
+env:
+  - GOLANGCILINT=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/golangci/golangci-lint/releases/latest | awk -F '/' '{print $8}')
 
 go_import_path: github.com/intel/ccloudvm
 
@@ -12,9 +15,8 @@ matrix:
   - go: tip
 
 before_install:
-  - go get github.com/alecthomas/gometalinter
-  - gometalinter --install
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCILINT}
 
 script:
    - go env
-   - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode ./...
+   - golangci-lint run -c ./.golangci.yml ./...

--- a/ccvm/download_test.go
+++ b/ccvm/download_test.go
@@ -180,7 +180,7 @@ func testDownloadCancelOneOfTwo(ctx context.Context, t *testing.T, downloadCh ch
 
 	cancel()
 	ret1 := <-params[0].ch
-	_ = <-params[1].ch
+	<-params[1].ch
 
 	if ret1.err != nil {
 		t.Errorf("Download failed : %v", ret1.err)

--- a/ccvm/instance.go
+++ b/ccvm/instance.go
@@ -67,35 +67,6 @@ func defaultWorkload() *workload {
 	}
 }
 
-func unmarshal(in *types.VMSpec, data []byte) error {
-	err := yaml.Unmarshal(data, in)
-	if err != nil {
-		return errors.Wrap(err, "Unable to unmarshal instance state")
-	}
-
-	for i := range in.Mounts {
-		if err := types.CheckDirectory(in.Mounts[i].Path); err != nil {
-			return fmt.Errorf("Bad mount %s specified: %v",
-				in.Mounts[i].Path, err)
-		}
-	}
-
-	return nil
-}
-
-func unmarshalWithTemplate(in *types.VMSpec, ws *workspace, data string) error {
-	tmpl, err := template.New("instance-data").Parse(string(data))
-	if err != nil {
-		return errors.Wrap(err, "Unable to parse instance data template")
-	}
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, ws)
-	if err != nil {
-		return errors.Wrap(err, "Unable to execute instance data template")
-	}
-	return unmarshal(in, buf.Bytes())
-}
-
 func (ins *workloadSpec) unmarshal(data []byte) error {
 	err := yaml.Unmarshal(data, ins)
 	if err != nil {

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -303,7 +303,7 @@ func buildISOImage(ctx context.Context, resultCh chan interface{}, userData []by
 			Line: string(userData),
 		}
 		resultCh <- types.CreateResult{
-			Line: string(mdBuf.Bytes()),
+			Line: mdBuf.String(),
 		}
 	}
 

--- a/ccvm/server.go
+++ b/ccvm/server.go
@@ -50,7 +50,7 @@ var hostnameRegexp *regexp.Regexp
 
 func init() {
 	flag.BoolVar(&systemd, "systemd", true, "Use systemd socket activation if true")
-	hostnameRegexp = regexp.MustCompile("^[A-Za-z0-9\\-]+$")
+	hostnameRegexp = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 }
 
 type service interface {
@@ -239,7 +239,7 @@ func (s *ccvmService) findFreeIP() (net.IP, uint32, error) {
 func (s *ccvmService) findExistingInstances() {
 	instancesDir := filepath.Join(s.ccvmDir, "instances")
 
-	_ = filepath.Walk(instancesDir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(instancesDir, func(path string, info os.FileInfo, ferr error) error {
 		if path == instancesDir {
 			return nil
 		}
@@ -496,7 +496,7 @@ func (s *ccvmService) processAction(action interface{}) {
 		}
 		if s.shutdownTimer != nil {
 			if !s.shutdownTimer.Stop() {
-				_ = <-s.shutdownTimer.C
+				<-s.shutdownTimer.C
 			}
 			s.shutdownTimer = nil
 			s.cases[TimeChIndex].Chan = reflect.ValueOf(nil)
@@ -563,7 +563,7 @@ DONE:
 			fmt.Printf("Signal received active transactions = %d\n", len(s.transactions))
 			if s.shutdownTimer != nil {
 				if !s.shutdownTimer.Stop() {
-					_ = <-s.shutdownTimer.C
+					<-s.shutdownTimer.C
 				}
 			}
 			for _, t := range s.transactions {

--- a/ccvm/server_test.go
+++ b/ccvm/server_test.go
@@ -500,7 +500,7 @@ func TestServerShutdownPending(t *testing.T) {
 		transCh: transCh,
 	}
 
-	_ = <-transCh
+	<-transCh
 
 	close(doneCh)
 	wg.Wait()

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -193,7 +193,7 @@ func startHTTPServer(ctx context.Context, resultCh chan interface{}, downloadCh 
 			// TODO: Figure out what to do here
 			return
 		}
-		line := string(b.Bytes())
+		line := b.String()
 		if line == "FINISHED" {
 			finished = true
 			_ = listener.Close()

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -44,7 +44,7 @@ const ccloudvmPkg = "github.com/intel/ccloudvm"
 var indentedRegexp *regexp.Regexp
 
 func init() {
-	indentedRegexp = regexp.MustCompile("\\s+.*")
+	indentedRegexp = regexp.MustCompile(`\s+.*`)
 }
 
 type workload struct {


### PR DESCRIPTION
gometalinter is now officially deprecated and will be archived end of
Q1. Their recommendation is to switch to
golangci-lint(https://github.com/golangci/golangci-lint) which is
apparently 5x faster than gometalinter

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>