### PR TITLE
Update fedora download path

### DIFF
--- a/ccvm/workloads/fedora27.yaml
+++ b/ccvm/workloads/fedora27.yaml
@@ -1,5 +1,5 @@
 ---
-base_image_url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+base_image_url: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
 base_image_name: Fedora 27
 vm:
   disk_gib: 16

--- a/ccvm/workloads/fedora28.yaml
+++ b/ccvm/workloads/fedora28.yaml
@@ -1,5 +1,5 @@
 ---
-base_image_url: https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2
+base_image_url: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2
 base_image_name: Fedora 28
 vm:
   disk_gib: 16

--- a/ccvm/workloads/fedora29.yaml
+++ b/ccvm/workloads/fedora29.yaml
@@ -1,5 +1,5 @@
 ---
-base_image_url: http://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2
+base_image_url: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2
 base_image_name: Fedora 29
 vm:
   disk_gib: 16

--- a/ccvm/workloads/fedora30.yaml
+++ b/ccvm/workloads/fedora30.yaml
@@ -1,5 +1,5 @@
 ---
-base_image_url: http://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2
+base_image_url: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2
 base_image_name: Fedora 30 
 vm:
   disk_gib: 16

--- a/ccvm/workloads/fedora31.yaml
+++ b/ccvm/workloads/fedora31.yaml
@@ -1,5 +1,5 @@
 ---
-base_image_url: http://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
+base_image_url: https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
 base_image_name: Fedora 31 
 vm:
   disk_gib: 16


### PR DESCRIPTION
Fedora releases until 31 have been moved to an archived location.
Switching the download URL